### PR TITLE
feat: sage-starbased-decoder patch movement

### DIFF
--- a/carbon-decoders/sage-starbased-decoder/src/instructions/start_subwarp.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/start_subwarp.rs
@@ -12,7 +12,13 @@ pub struct StartSubwarp {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StartSubwarpInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for StartSubwarp {
@@ -22,10 +28,22 @@ impl carbon_core::deserialize::ArrangeAccounts for StartSubwarp {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
 
         Some(StartSubwarpInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
         })
     }
 }

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/stop_subwarp.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/stop_subwarp.rs
@@ -12,7 +12,13 @@ pub struct StopSubwarp {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StopSubwarpInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for StopSubwarp {
@@ -22,10 +28,22 @@ impl carbon_core::deserialize::ArrangeAccounts for StopSubwarp {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
 
         Some(StopSubwarpInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
         })
     }
 }

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/warp_lane.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/warp_lane.rs
@@ -12,7 +12,14 @@ pub struct WarpLane {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct WarpLaneInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub from_starbase: solana_pubkey::Pubkey,
     pub to_starbase: solana_pubkey::Pubkey,
     pub from_sector: solana_pubkey::Pubkey,
@@ -36,7 +43,16 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpLane {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // Direct accounts
         let from_starbase = next_account(&mut iter)?;
         let to_starbase = next_account(&mut iter)?;
         let from_sector = next_account(&mut iter)?;
@@ -53,7 +69,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpLane {
         let token_program = next_account(&mut iter)?;
 
         Some(WarpLaneInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             from_starbase,
             to_starbase,
             from_sector,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/warp_to_coordinate.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/warp_to_coordinate.rs
@@ -12,7 +12,14 @@ pub struct WarpToCoordinate {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct WarpToCoordinateInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub fuel_tank: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub stats_definition: solana_pubkey::Pubkey,
@@ -29,7 +36,16 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpToCoordinate {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // Direct accounts
         let fuel_tank = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let stats_definition = next_account(&mut iter)?;
@@ -39,7 +55,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpToCoordinate {
         let token_program = next_account(&mut iter)?;
 
         Some(WarpToCoordinateInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             fuel_tank,
             cargo_type,
             stats_definition,

--- a/patches/sage-starbased-03-instructions-movement.patch
+++ b/patches/sage-starbased-03-instructions-movement.patch
@@ -1,0 +1,192 @@
+diff --git a/src/instructions/start_subwarp.rs b/src/instructions/start_subwarp.rs
+index 5db456b..4913304 100644
+--- a/src/instructions/start_subwarp.rs
++++ b/src/instructions/start_subwarp.rs
+@@ -12,7 +12,13 @@ pub struct StartSubwarp {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StartSubwarpInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+ }
+ 
+ impl carbon_core::deserialize::ArrangeAccounts for StartSubwarp {
+@@ -22,10 +28,22 @@ impl carbon_core::deserialize::ArrangeAccounts for StartSubwarp {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
+ 
+         Some(StartSubwarpInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+         })
+     }
+ }
+diff --git a/src/instructions/stop_subwarp.rs b/src/instructions/stop_subwarp.rs
+index bbbe842..fc101ac 100644
+--- a/src/instructions/stop_subwarp.rs
++++ b/src/instructions/stop_subwarp.rs
+@@ -12,7 +12,13 @@ pub struct StopSubwarp {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StopSubwarpInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+ }
+ 
+ impl carbon_core::deserialize::ArrangeAccounts for StopSubwarp {
+@@ -22,10 +28,22 @@ impl carbon_core::deserialize::ArrangeAccounts for StopSubwarp {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
+ 
+         Some(StopSubwarpInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+         })
+     }
+ }
+diff --git a/src/instructions/warp_lane.rs b/src/instructions/warp_lane.rs
+index 278efd7..212a0a6 100644
+--- a/src/instructions/warp_lane.rs
++++ b/src/instructions/warp_lane.rs
+@@ -12,7 +12,14 @@ pub struct WarpLane {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct WarpLaneInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub from_starbase: solana_pubkey::Pubkey,
+     pub to_starbase: solana_pubkey::Pubkey,
+     pub from_sector: solana_pubkey::Pubkey,
+@@ -36,7 +43,16 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpLane {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // Direct accounts
+         let from_starbase = next_account(&mut iter)?;
+         let to_starbase = next_account(&mut iter)?;
+         let from_sector = next_account(&mut iter)?;
+@@ -53,7 +69,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpLane {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(WarpLaneInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             from_starbase,
+             to_starbase,
+             from_sector,
+diff --git a/src/instructions/warp_to_coordinate.rs b/src/instructions/warp_to_coordinate.rs
+index 80b4e6c..571d1af 100644
+--- a/src/instructions/warp_to_coordinate.rs
++++ b/src/instructions/warp_to_coordinate.rs
+@@ -12,7 +12,14 @@ pub struct WarpToCoordinate {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct WarpToCoordinateInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub fuel_tank: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub stats_definition: solana_pubkey::Pubkey,
+@@ -29,7 +36,16 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpToCoordinate {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // Direct accounts
+         let fuel_tank = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let stats_definition = next_account(&mut iter)?;
+@@ -39,7 +55,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpToCoordinate {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(WarpToCoordinateInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             fuel_tank,
+             cargo_type,
+             stats_definition,


### PR DESCRIPTION
# Expanded Fleet Movement Instruction Accounts

### TL;DR

Expanded the account structure for fleet movement instructions to properly decode all accounts in the GameAndGameStateAndFleetAndOwnerMut composite.

### What changed?

- Expanded the single `game_accounts_fleet_and_owner` field into its six component accounts in:
  - `StartSubwarp`
  - `StopSubwarp`
  - `WarpLane`
  - `WarpToCoordinate`
- Added clear comments to distinguish between composite account expansions and direct accounts
- Updated the corresponding `arrange_accounts` implementations to properly extract all accounts
- Enhanced documentation with guidance on creating sequential patches and comment style conventions

### How to test?

1. Build and test the decoder:
```bash
just all-sage-starbased
```

2. Verify the expanded account structures are correctly decoded when processing fleet movement transactions

### Why make this change?

The previous implementation used a single field to represent multiple accounts, making it impossible to access individual accounts like the fleet or game state. This expansion provides full access to all accounts in fleet movement instructions, enabling more detailed transaction analysis and better integration with tools that need to track specific accounts.