### PR TITLE
chore: workspace crate deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,13 @@ edition = "2024"
 publish = false
 license = "Apache-2.0"
 repository = "https://github.com/staratlasmeta/star-atlas-decoders"
+
+[workspace.dependencies]
+carbon-core = "0.10.0"
+carbon-proc-macros = "0.10.0"
+carbon-macros = "0.10.0"
+solana-account = "2.2.1"
+solana-instruction = { version = "2.3.0", default-features = false }
+solana-pubkey = { version = "2.4.0", features = ["borsh", "serde", "bytemuck"] }
+serde = { version = "1.0", features = ["derive"] }
+serde-big-array = "0.5.1"

--- a/carbon-decoders/sage-holosim-decoder/Cargo.toml
+++ b/carbon-decoders/sage-holosim-decoder/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "sage-holosim-decoder"
 version = "0.10.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]
 
 [dependencies]
-carbon-core = "0.10.0"
-carbon-proc-macros = "0.10.0"
-carbon-macros = "0.10.0"
-solana-account = "2.2.1"
-solana-instruction = { version = "2.3.0", default-features = false }
-solana-pubkey = { version = "2.4.0", features = ["borsh", "serde", "bytemuck"] }
-serde = { version = "1.0", features = ["derive"] }
-serde-big-array = "0.5.1"
+carbon-core = { workspace = true }
+carbon-proc-macros = { workspace = true }
+carbon-macros = { workspace = true }
+solana-account = { workspace = true }
+solana-instruction = { workspace = true }
+solana-pubkey = { workspace = true }
+serde = { workspace = true }
+serde-big-array = { workspace = true }

--- a/carbon-decoders/sage-starbased-decoder/Cargo.toml
+++ b/carbon-decoders/sage-starbased-decoder/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "sage-starbased-decoder"
 version = "0.10.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]
 
 [dependencies]
-carbon-core = "0.10.0"
-carbon-proc-macros = "0.10.0"
-carbon-macros = "0.10.0"
-solana-account = "2.2.1"
-solana-instruction = { version = "2.3.0", default-features = false }
-solana-pubkey = { version = "2.4.0", features = ["borsh", "serde", "bytemuck"] }
-serde = { version = "1.0", features = ["derive"] }
-serde-big-array = "0.5.1"
+carbon-core = { workspace = true }
+carbon-proc-macros = { workspace = true }
+carbon-macros = { workspace = true }
+solana-account = { workspace = true }
+solana-instruction = { workspace = true }
+solana-pubkey = { workspace = true }
+serde = { workspace = true }
+serde-big-array = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -38,6 +38,20 @@ _fix-workspace-refs decoder_name:
     just _sed 's/serde-big-array = { workspace = true }/serde-big-array = "0.5.1"/' ./dist/{{decoder_name}}/Cargo.toml
     @echo "✅ Workspace references fixed"
 
+# Restore workspace references after publishing to workspace
+_restore-workspace-refs decoder_name:
+    @echo "Restoring workspace references for {{decoder_name}}..."
+    just _sed 's/edition = "2024"/edition = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    just _sed 's/carbon-core = "0.10.0"/carbon-core = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    just _sed 's/carbon-proc-macros = "0.10.0"/carbon-proc-macros = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    just _sed 's/carbon-macros = "0.10.0"/carbon-macros = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    just _sed 's/solana-account = "2.2.1"/solana-account = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    just _sed 's/solana-instruction = { version = "2.3.0", default-features = false }/solana-instruction = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    just _sed 's/solana-pubkey = { version = "2.4.0", features = \["borsh", "serde", "bytemuck"\] }/solana-pubkey = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    just _sed 's/serde = { version = "1.0", features = \["derive"\] }/serde = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    just _sed 's/serde-big-array = "0.5.1"/serde-big-array = { workspace = true }/' ./carbon-decoders/{{decoder_name}}-decoder/Cargo.toml
+    @echo "✅ Workspace references restored"
+
 # Prepare generated code by fixing compilation issues
 _prepare-decoder decoder_name:
     #!/bin/bash
@@ -96,6 +110,7 @@ _publish-decoder decoder_name:
     rm -f ./dist/{{decoder_name}}/Cargo.lock
     mv ./dist/{{decoder_name}} ./carbon-decoders/{{decoder_name}}-decoder
     @echo "✅ Decoder published to ./carbon-decoders/{{decoder_name}}-decoder"
+    just _restore-workspace-refs {{decoder_name}}
     @echo "Verifying in workspace..."
     cargo check -p {{decoder_name}}-decoder
     @echo "✅ Decoder works in main workspace"


### PR DESCRIPTION
# Implement Cargo Workspace Dependencies

### TL;DR

Configured Cargo workspace dependencies to centralize dependency management across decoder crates.

### What changed?

- Added `[workspace.dependencies]` section in the root `Cargo.toml` to define shared dependencies
- Updated decoder crates to use workspace references (`{ workspace = true }`) for dependencies
- Added a new `_restore-workspace-refs` function in the justfile to restore workspace references after publishing

### How to test?

1. Run `cargo check` to verify the workspace builds correctly
2. Test the decoder publishing workflow with `just publish-decoder <decoder-name>`
3. Verify that the workspace references are properly restored after publishing

### Why make this change?

This change centralizes dependency management, making it easier to maintain consistent versions across all decoder crates. It reduces duplication and simplifies future dependency updates, as they only need to be changed in one place. The new justfile function ensures that workspace references are properly restored after the publishing process.