### PR TITLE
feat: sage-starbased-decoder patch crafting

### DIFF
--- a/carbon-decoders/sage-starbased-decoder/src/instructions/burn_crafting_consumables.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/burn_crafting_consumables.rs
@@ -12,12 +12,18 @@ pub struct BurnCraftingConsumables {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BurnCraftingConsumablesInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
-    pub game_accounts: solana_pubkey::Pubkey,
+    // GameAndGameState expansion
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub token_from: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -31,24 +37,32 @@ impl carbon_core::deserialize::ArrangeAccounts for BurnCraftingConsumables {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
-        let game_accounts = next_account(&mut iter)?;
+        // GameAndGameState expansion
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+        // Direct accounts
         let token_from = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
         let token_program = next_account(&mut iter)?;
 
         Some(BurnCraftingConsumablesInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_facility,
             crafting_recipe,
-            game_accounts,
+            game_id,
+            game_state,
             token_from,
             token_mint,
             crafting_program,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/cancel_crafting_process.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/cancel_crafting_process.rs
@@ -12,12 +12,22 @@ pub struct CancelCraftingProcess {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CancelCraftingProcessInstructionAccounts {
+    // Direct accounts
     pub funds_to: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_program: solana_pubkey::Pubkey,
 }
 
@@ -28,21 +38,36 @@ impl carbon_core::deserialize::ArrangeAccounts for CancelCraftingProcess {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
+        // Direct accounts
         let funds_to = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_program = next_account(&mut iter)?;
 
         Some(CancelCraftingProcessInstructionAccounts {
             funds_to,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_facility,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
         })
     }

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/claim_crafting_non_consumables.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/claim_crafting_non_consumables.rs
@@ -12,7 +12,10 @@ pub struct ClaimCraftingNonConsumables {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ClaimCraftingNonConsumablesInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
@@ -20,7 +23,10 @@ pub struct ClaimCraftingNonConsumablesInstructionAccounts {
     pub cargo_pod_to: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts: solana_pubkey::Pubkey,
+    // GameAndGameState expansion
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
@@ -36,7 +42,10 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
@@ -44,7 +53,10 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
         let cargo_pod_to = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts = next_account(&mut iter)?;
+        // GameAndGameState expansion
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+        // Direct accounts
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
@@ -53,7 +65,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
         let token_program = next_account(&mut iter)?;
 
         Some(ClaimCraftingNonConsumablesInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_facility,
@@ -61,7 +74,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
             cargo_pod_to,
             cargo_type,
             cargo_stats_definition,
-            game_accounts,
+            game_id,
+            game_state,
             token_from,
             token_to,
             token_mint,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/claim_crafting_outputs.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/claim_crafting_outputs.rs
@@ -12,7 +12,10 @@ pub struct ClaimCraftingOutputs {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ClaimCraftingOutputsInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
@@ -21,7 +24,10 @@ pub struct ClaimCraftingOutputsInstructionAccounts {
     pub cargo_pod_to: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts: solana_pubkey::Pubkey,
+    // GameAndGameState expansion
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -36,7 +42,10 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
@@ -45,7 +54,10 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
         let cargo_pod_to = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts = next_account(&mut iter)?;
+        // GameAndGameState expansion
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+        // Direct accounts
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
@@ -53,7 +65,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
         let token_program = next_account(&mut iter)?;
 
         Some(ClaimCraftingOutputsInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_facility,
@@ -62,7 +75,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
             cargo_pod_to,
             cargo_type,
             cargo_stats_definition,
-            game_accounts,
+            game_id,
+            game_state,
             token_from,
             token_to,
             crafting_program,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/close_crafting_process.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/close_crafting_process.rs
@@ -12,15 +12,31 @@ pub struct CloseCraftingProcess {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CloseCraftingProcessInstructionAccounts {
+    // Direct accounts
     pub funds_to: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
-    pub crafting_xp_accounts: solana_pubkey::Pubkey,
-    pub council_rank_xp_accounts: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (crafting_xp_accounts)
+    pub crafting_user_points_account: solana_pubkey::Pubkey,
+    pub crafting_points_category: solana_pubkey::Pubkey,
+    pub crafting_points_modifier_account: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (council_rank_xp_accounts)
+    pub council_rank_user_points_account: solana_pubkey::Pubkey,
+    pub council_rank_points_category: solana_pubkey::Pubkey,
+    pub council_rank_points_modifier_account: solana_pubkey::Pubkey,
+    // Direct accounts
     pub progression_config: solana_pubkey::Pubkey,
     pub points_program: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -33,29 +49,54 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseCraftingProcess {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
+        // Direct accounts
         let funds_to = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
-        let crafting_xp_accounts = next_account(&mut iter)?;
-        let council_rank_xp_accounts = next_account(&mut iter)?;
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+        // PointsModificationAccounts expansion (crafting_xp_accounts)
+        let crafting_user_points_account = next_account(&mut iter)?;
+        let crafting_points_category = next_account(&mut iter)?;
+        let crafting_points_modifier_account = next_account(&mut iter)?;
+        // PointsModificationAccounts expansion (council_rank_xp_accounts)
+        let council_rank_user_points_account = next_account(&mut iter)?;
+        let council_rank_points_category = next_account(&mut iter)?;
+        let council_rank_points_modifier_account = next_account(&mut iter)?;
+        // Direct accounts
         let progression_config = next_account(&mut iter)?;
         let points_program = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
 
         Some(CloseCraftingProcessInstructionAccounts {
             funds_to,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_recipe,
             crafting_facility,
-            game_accounts_and_profile,
-            crafting_xp_accounts,
-            council_rank_xp_accounts,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
+            crafting_user_points_account,
+            crafting_points_category,
+            crafting_points_modifier_account,
+            council_rank_user_points_account,
+            council_rank_points_category,
+            council_rank_points_modifier_account,
             progression_config,
             points_program,
             crafting_program,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/create_crafting_process.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/create_crafting_process.rs
@@ -12,14 +12,24 @@ pub struct CreateCraftingProcess {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateCraftingProcessInstructionAccounts {
+    // Direct accounts
     pub funder: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_domain: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
@@ -31,26 +41,41 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateCraftingProcess {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
+        // Direct accounts
         let funder = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_domain = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_program = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
         Some(CreateCraftingProcessInstructionAccounts {
             funder,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_facility,
             crafting_process,
             crafting_recipe,
             crafting_domain,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
             system_program,
         })

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/deposit_crafting_ingredient.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/deposit_crafting_ingredient.rs
@@ -12,7 +12,10 @@ pub struct DepositCraftingIngredient {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DepositCraftingIngredientInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
@@ -20,7 +23,13 @@ pub struct DepositCraftingIngredientInstructionAccounts {
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -35,7 +44,12 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
@@ -43,7 +57,15 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
         let crafting_recipe = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // Direct accounts
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
@@ -51,7 +73,8 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
         let token_program = next_account(&mut iter)?;
 
         Some(DepositCraftingIngredientInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_facility,
             crafting_process,
@@ -59,7 +82,11 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
             crafting_recipe,
             cargo_type,
             cargo_stats_definition,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             token_from,
             token_to,
             crafting_program,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/start_crafting_process.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/start_crafting_process.rs
@@ -12,12 +12,21 @@ pub struct StartCraftingProcess {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StartCraftingProcessInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_program: solana_pubkey::Pubkey,
 }
 
@@ -28,21 +37,35 @@ impl carbon_core::deserialize::ArrangeAccounts for StartCraftingProcess {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_program = next_account(&mut iter)?;
 
         Some(StartCraftingProcessInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_recipe,
             crafting_facility,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
         })
     }

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/stop_crafting_process.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/stop_crafting_process.rs
@@ -12,12 +12,21 @@ pub struct StopCraftingProcess {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StopCraftingProcessInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_program: solana_pubkey::Pubkey,
 }
 
@@ -28,21 +37,35 @@ impl carbon_core::deserialize::ArrangeAccounts for StopCraftingProcess {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+        // Direct accounts
         let crafting_program = next_account(&mut iter)?;
 
         Some(StopCraftingProcessInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_recipe,
             crafting_facility,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
         })
     }

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/withdraw_crafting_ingredient.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/withdraw_crafting_ingredient.rs
@@ -12,7 +12,10 @@ pub struct WithdrawCraftingIngredient {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct WithdrawCraftingIngredientInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
@@ -20,7 +23,13 @@ pub struct WithdrawCraftingIngredientInstructionAccounts {
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
@@ -36,7 +45,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
+        // Direct accounts
         let crafting_instance = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
@@ -44,7 +58,15 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
         let crafting_recipe = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // Direct accounts
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
@@ -53,7 +75,8 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
         let token_program = next_account(&mut iter)?;
 
         Some(WithdrawCraftingIngredientInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_facility,
             crafting_process,
@@ -61,7 +84,11 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
             crafting_recipe,
             cargo_type,
             cargo_stats_definition,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             token_from,
             token_to,
             token_mint,

--- a/patches/sage-starbased-05-instructions-crafting.patch
+++ b/patches/sage-starbased-05-instructions-crafting.patch
@@ -1,0 +1,762 @@
+diff --git a/src/instructions/burn_crafting_consumables.rs b/src/instructions/burn_crafting_consumables.rs
+index 897153a..4a35031 100644
+--- a/src/instructions/burn_crafting_consumables.rs
++++ b/src/instructions/burn_crafting_consumables.rs
+@@ -12,12 +12,18 @@ pub struct BurnCraftingConsumables {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct BurnCraftingConsumablesInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -31,24 +37,32 @@ impl carbon_core::deserialize::ArrangeAccounts for BurnCraftingConsumables {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let token_from = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(BurnCraftingConsumablesInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_facility,
+             crafting_recipe,
+-            game_accounts,
++            game_id,
++            game_state,
+             token_from,
+             token_mint,
+             crafting_program,
+diff --git a/src/instructions/cancel_crafting_process.rs b/src/instructions/cancel_crafting_process.rs
+index f66e97d..1d4fcef 100644
+--- a/src/instructions/cancel_crafting_process.rs
++++ b/src/instructions/cancel_crafting_process.rs
+@@ -12,12 +12,22 @@ pub struct CancelCraftingProcess {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CancelCraftingProcessInstructionAccounts {
++    // Direct accounts
+     pub funds_to: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -28,21 +38,36 @@ impl carbon_core::deserialize::ArrangeAccounts for CancelCraftingProcess {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
++        // Direct accounts
+         let funds_to = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(CancelCraftingProcessInstructionAccounts {
+             funds_to,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_facility,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+         })
+     }
+diff --git a/src/instructions/claim_crafting_non_consumables.rs b/src/instructions/claim_crafting_non_consumables.rs
+index 4154597..3fa608c 100644
+--- a/src/instructions/claim_crafting_non_consumables.rs
++++ b/src/instructions/claim_crafting_non_consumables.rs
+@@ -12,7 +12,10 @@ pub struct ClaimCraftingNonConsumables {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct ClaimCraftingNonConsumablesInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+@@ -20,7 +23,10 @@ pub struct ClaimCraftingNonConsumablesInstructionAccounts {
+     pub cargo_pod_to: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+@@ -36,7 +42,10 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+@@ -44,7 +53,10 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
+         let cargo_pod_to = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+@@ -53,7 +65,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(ClaimCraftingNonConsumablesInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_facility,
+@@ -61,7 +74,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
+             cargo_pod_to,
+             cargo_type,
+             cargo_stats_definition,
+-            game_accounts,
++            game_id,
++            game_state,
+             token_from,
+             token_to,
+             token_mint,
+diff --git a/src/instructions/claim_crafting_outputs.rs b/src/instructions/claim_crafting_outputs.rs
+index dcb2695..40ccfcd 100644
+--- a/src/instructions/claim_crafting_outputs.rs
++++ b/src/instructions/claim_crafting_outputs.rs
+@@ -12,7 +12,10 @@ pub struct ClaimCraftingOutputs {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct ClaimCraftingOutputsInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+@@ -21,7 +24,10 @@ pub struct ClaimCraftingOutputsInstructionAccounts {
+     pub cargo_pod_to: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -36,7 +42,10 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+@@ -45,7 +54,10 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
+         let cargo_pod_to = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+@@ -53,7 +65,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(ClaimCraftingOutputsInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_facility,
+@@ -62,7 +75,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
+             cargo_pod_to,
+             cargo_type,
+             cargo_stats_definition,
+-            game_accounts,
++            game_id,
++            game_state,
+             token_from,
+             token_to,
+             crafting_program,
+diff --git a/src/instructions/close_crafting_process.rs b/src/instructions/close_crafting_process.rs
+index 2d39a21..f080a2b 100644
+--- a/src/instructions/close_crafting_process.rs
++++ b/src/instructions/close_crafting_process.rs
+@@ -12,15 +12,31 @@ pub struct CloseCraftingProcess {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CloseCraftingProcessInstructionAccounts {
++    // Direct accounts
+     pub funds_to: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+-    pub crafting_xp_accounts: solana_pubkey::Pubkey,
+-    pub council_rank_xp_accounts: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (crafting_xp_accounts)
++    pub crafting_user_points_account: solana_pubkey::Pubkey,
++    pub crafting_points_category: solana_pubkey::Pubkey,
++    pub crafting_points_modifier_account: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (council_rank_xp_accounts)
++    pub council_rank_user_points_account: solana_pubkey::Pubkey,
++    pub council_rank_points_category: solana_pubkey::Pubkey,
++    pub council_rank_points_modifier_account: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub progression_config: solana_pubkey::Pubkey,
+     pub points_program: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -33,29 +49,54 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseCraftingProcess {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
++        // Direct accounts
+         let funds_to = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
+-        let crafting_xp_accounts = next_account(&mut iter)?;
+-        let council_rank_xp_accounts = next_account(&mut iter)?;
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // PointsModificationAccounts expansion (crafting_xp_accounts)
++        let crafting_user_points_account = next_account(&mut iter)?;
++        let crafting_points_category = next_account(&mut iter)?;
++        let crafting_points_modifier_account = next_account(&mut iter)?;
++        // PointsModificationAccounts expansion (council_rank_xp_accounts)
++        let council_rank_user_points_account = next_account(&mut iter)?;
++        let council_rank_points_category = next_account(&mut iter)?;
++        let council_rank_points_modifier_account = next_account(&mut iter)?;
++        // Direct accounts
+         let progression_config = next_account(&mut iter)?;
+         let points_program = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(CloseCraftingProcessInstructionAccounts {
+             funds_to,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_recipe,
+             crafting_facility,
+-            game_accounts_and_profile,
+-            crafting_xp_accounts,
+-            council_rank_xp_accounts,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
++            crafting_user_points_account,
++            crafting_points_category,
++            crafting_points_modifier_account,
++            council_rank_user_points_account,
++            council_rank_points_category,
++            council_rank_points_modifier_account,
+             progression_config,
+             points_program,
+             crafting_program,
+diff --git a/src/instructions/create_crafting_process.rs b/src/instructions/create_crafting_process.rs
+index 362d7f5..0125263 100644
+--- a/src/instructions/create_crafting_process.rs
++++ b/src/instructions/create_crafting_process.rs
+@@ -12,14 +12,24 @@ pub struct CreateCraftingProcess {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CreateCraftingProcessInstructionAccounts {
++    // Direct accounts
+     pub funder: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_domain: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -31,26 +41,41 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateCraftingProcess {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
++        // Direct accounts
+         let funder = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_domain = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(CreateCraftingProcessInstructionAccounts {
+             funder,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_facility,
+             crafting_process,
+             crafting_recipe,
+             crafting_domain,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+             system_program,
+         })
+diff --git a/src/instructions/deposit_crafting_ingredient.rs b/src/instructions/deposit_crafting_ingredient.rs
+index 61bb970..342efa3 100644
+--- a/src/instructions/deposit_crafting_ingredient.rs
++++ b/src/instructions/deposit_crafting_ingredient.rs
+@@ -12,7 +12,10 @@ pub struct DepositCraftingIngredient {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct DepositCraftingIngredientInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+@@ -20,7 +23,13 @@ pub struct DepositCraftingIngredientInstructionAccounts {
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -35,7 +44,12 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+@@ -43,7 +57,15 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
+         let crafting_recipe = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // Direct accounts
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+@@ -51,7 +73,8 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(DepositCraftingIngredientInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_facility,
+             crafting_process,
+@@ -59,7 +82,11 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
+             crafting_recipe,
+             cargo_type,
+             cargo_stats_definition,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             token_from,
+             token_to,
+             crafting_program,
+diff --git a/src/instructions/start_crafting_process.rs b/src/instructions/start_crafting_process.rs
+index 589506b..1e4838f 100644
+--- a/src/instructions/start_crafting_process.rs
++++ b/src/instructions/start_crafting_process.rs
+@@ -12,12 +12,21 @@ pub struct StartCraftingProcess {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StartCraftingProcessInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -28,21 +37,35 @@ impl carbon_core::deserialize::ArrangeAccounts for StartCraftingProcess {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(StartCraftingProcessInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_recipe,
+             crafting_facility,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+         })
+     }
+diff --git a/src/instructions/stop_crafting_process.rs b/src/instructions/stop_crafting_process.rs
+index 35af4eb..4221b69 100644
+--- a/src/instructions/stop_crafting_process.rs
++++ b/src/instructions/stop_crafting_process.rs
+@@ -12,12 +12,21 @@ pub struct StopCraftingProcess {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StopCraftingProcessInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -28,21 +37,35 @@ impl carbon_core::deserialize::ArrangeAccounts for StopCraftingProcess {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(StopCraftingProcessInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_recipe,
+             crafting_facility,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+         })
+     }
+diff --git a/src/instructions/withdraw_crafting_ingredient.rs b/src/instructions/withdraw_crafting_ingredient.rs
+index e89b47e..2e2bd15 100644
+--- a/src/instructions/withdraw_crafting_ingredient.rs
++++ b/src/instructions/withdraw_crafting_ingredient.rs
+@@ -12,7 +12,10 @@ pub struct WithdrawCraftingIngredient {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct WithdrawCraftingIngredientInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+@@ -20,7 +23,13 @@ pub struct WithdrawCraftingIngredientInstructionAccounts {
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+@@ -36,7 +45,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
++        // Direct accounts
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+@@ -44,7 +58,15 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
+         let crafting_recipe = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // Direct accounts
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+@@ -53,7 +75,8 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(WithdrawCraftingIngredientInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_facility,
+             crafting_process,
+@@ -61,7 +84,11 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
+             crafting_recipe,
+             cargo_type,
+             cargo_stats_definition,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             token_from,
+             token_to,
+             token_mint,


### PR DESCRIPTION
### TL;DR

Expanded account structures in crafting-related instructions to replace composite accounts with their individual components.

### What changed?

This PR expands several composite account structures in the sage-starbased-decoder's crafting instructions by replacing them with their individual component accounts:

- Replaced `starbase_and_starbase_player` with separate `starbase` and `starbase_player` accounts
- Expanded `game_accounts` into `game_id` and `game_state`
- Expanded `game_accounts_and_profile` into `key`, `profile`, `profile_faction`, `game_id`, and `game_state`
- Expanded `crafting_xp_accounts` and `council_rank_xp_accounts` into their respective component accounts

Added clear comments to indicate account expansions and direct accounts throughout the code, making the account structure more readable and maintainable.

### How to test?

1. Run the decoder against transactions that use these crafting instructions
2. Verify that the expanded account structures correctly decode the transaction data
3. Ensure that all crafting-related instructions (burn, cancel, claim, close, create, deposit, start, stop, withdraw) work as expected

### Why make this change?

This change improves the decoder's ability to accurately represent the on-chain account structure by:

1. Making the account relationships more explicit and easier to understand
2. Providing better visibility into the individual accounts used in crafting operations
3. Aligning with the actual on-chain account structure rather than using composite accounts
4. Enhancing maintainability by clearly documenting account expansions with comments