### PR TITLE
feat: sage-starbased-decoder patch fleet

### DIFF
--- a/docs/sage-starbased-patching-plan.md
+++ b/docs/sage-starbased-patching-plan.md
@@ -1,0 +1,320 @@
+# Sage Starbased Decoder - Comprehensive Patching Plan
+
+## Overview
+This document outlines the complete patching strategy for expanding composite accounts in the sage-starbased-decoder. The decoder has 106 instruction files that need composite account expansions to match the actual Solana program structure.
+
+## Progress Summary
+- **Total instruction files**: 106
+- **Completed patches**: 6 (covering 38 files)
+- **Remaining patches**: 10 (covering 68 files)
+- **Estimated total patches**: 16
+
+## Completed Patches (01-05)
+
+### Patch 01: Accounts
+- **Files**: 1 (fleet.rs)
+- **Purpose**: Custom deserialize for Fleet account with remaining data field
+- **Status**: ✅ Complete
+
+### Patch 02: Mining Instructions
+- **Files**: 2
+  - start_mining_asteroid.rs
+  - stop_mining_asteroid.rs
+- **Composite accounts**: `GameAndGameStateAndFleetAndOwnerMut`, `StarbaseMutAndStarbasePlayer`
+- **Status**: ✅ Complete
+
+### Patch 03: Movement Instructions
+- **Files**: 4
+  - start_subwarp.rs
+  - stop_subwarp.rs
+  - warp_lane.rs
+  - warp_to_coordinate.rs
+- **Composite accounts**: `GameAndGameStateAndFleetAndOwnerMut`
+- **Status**: ✅ Complete
+
+### Patch 04: Starbase Operations
+- **Files**: 7
+  - deposit_starbase_upkeep_resource.rs
+  - start_starbase_upgrade.rs
+  - complete_starbase_upgrade.rs
+  - submit_starbase_upgrade_resource.rs
+  - create_starbase_upgrade_resource_process.rs
+  - close_upgrade_process.rs
+  - sync_starbase_upgrade_ingredients.rs
+- **Composite accounts**:
+  - `StarbaseMutAndStarbasePlayer` → starbase, starbase_player
+  - `GameAndGameStateAndProfile` → key, profile, profile_faction, game_id, game_state
+  - `PointsModificationAccounts` → user_points_account, points_category, points_modifier_account
+- **Status**: ✅ Complete
+
+### Patch 05: Crafting Instructions
+- **Files**: 10
+  - deposit_crafting_ingredient.rs
+  - withdraw_crafting_ingredient.rs
+  - start_crafting_process.rs
+  - stop_crafting_process.rs
+  - create_crafting_process.rs
+  - cancel_crafting_process.rs
+  - close_crafting_process.rs
+  - claim_crafting_outputs.rs
+  - burn_crafting_consumables.rs
+  - claim_crafting_non_consumables.rs
+- **Composite accounts**:
+  - `StarbaseMutAndStarbasePlayer` → starbase, starbase_player
+  - `GameAndGameStateAndProfile` → key, profile, profile_faction, game_id, game_state (7 files)
+  - `GameAndGameState` → game_id, game_state (3 claim/burn files)
+  - `PointsModificationAccounts` (in close_crafting_process.rs)
+- **Status**: ✅ Complete
+
+---
+
+## Remaining Patches (06-16)
+
+### Priority 1: Core Gameplay (High Priority)
+
+#### Patch 06: Fleet Operations & State Transitions
+- **Files**: 15
+  - create_fleet.rs
+  - add_ship_to_fleet.rs
+  - disband_fleet.rs
+  - disbanded_fleet_to_escrow.rs
+  - force_disband_fleet.rs
+  - idle_to_loading_bay.rs
+  - loading_bay_to_idle.rs
+  - respawn_to_loading_bay.rs
+  - idle_to_respawn.rs
+  - mine_asteroid_to_respawn.rs
+  - load_fleet_crew.rs
+  - unload_fleet_crew.rs
+  - close_fleet_cargo_pod_token_account.rs
+  - update_ship_in_fleet.rs
+- **Composite accounts**:
+  - `GameAndGameStateAndFleetAndOwnerMut` → key, owning_profile, owning_profile_faction, fleet, game_id, game_state
+  - `FleetAndOwner` → key, owning_profile, owning_profile_faction, fleet
+  - `GameAndProfile` → key, profile, game_id
+  - `StarbaseMutAndStarbasePlayer` → starbase, starbase_player
+  - `GameAndGameState` → game_id, game_state
+- **Complexity**: Medium-High (complex state machine)
+- **Priority**: 🔴 High - Core fleet functionality
+- **Status**: ✅ Complete (805 lines)
+
+#### Patch 07: Fleet Cargo Operations
+- **Files**: ~4
+  - deposit_cargo_to_fleet.rs
+  - withdraw_cargo_from_fleet.rs
+  - transfer_cargo_within_fleet.rs
+  - set_next_ship.rs
+- **Composite accounts**:
+  - `GameAndGameStateAndFleetAndOwnerMut`
+  - `StarbaseMutAndStarbasePlayer`
+- **Complexity**: Medium
+- **Priority**: 🔴 High - Frequently used operations
+- **Status**: 🔲 Pending
+
+#### Patch 11: Scanning & Discovery
+- **Files**: ~3
+  - scan_for_survey_data_units.rs
+  - discover_sector.rs
+  - fleet_state_handler.rs
+- **Composite accounts**:
+  - `GameAndGameStateAndFleetAndOwnerMut`
+  - `PointsModificationAccounts` (XP rewards in scanning)
+- **Complexity**: Medium-High (includes XP account expansions)
+- **Priority**: 🔴 High - Core gameplay mechanic
+- **Status**: 🔲 Pending
+
+---
+
+### Priority 2: Frequently Used Operations (Medium Priority)
+
+#### Patch 08: Starbase Cargo & Player Operations
+- **Files**: ~9
+- **Functional areas**:
+  - Cargo pods: create_cargo_pod, remove_cargo_pod, close_starbase_cargo_token_account
+  - Game cargo: deposit_cargo_to_game, withdraw_cargo_from_game, dev_deposit_cargo_to_game, transfer_cargo_at_starbase
+  - Player: register_starbase_player, sync_starbase_player
+- **Composite accounts**:
+  - `StarbaseMutAndStarbasePlayer`
+  - `GameAndGameStateAndProfile`
+- **Complexity**: Medium
+- **Priority**: 🟡 Medium - Frequently used
+- **Status**: 🔲 Pending
+
+#### Patch 09: Crew & Player Management
+- **Files**: ~5
+  - add_crew_to_game.rs
+  - remove_crew_from_game.rs
+  - dev_add_crew_to_game.rs
+  - mint_crew_to_game.rs
+  - close_player_crew_record.rs
+- **Composite accounts**:
+  - `StarbaseMutAndStarbasePlayer`
+  - `GameAndProfileAndFaction`
+- **Complexity**: Medium
+- **Priority**: 🟡 Medium
+- **Status**: 🔲 Pending
+
+#### Patch 10: Ship Escrow & Management
+- **Files**: ~6
+  - add_ship_escrow.rs
+  - remove_ship_escrow.rs
+  - update_ship_escrow.rs
+  - remove_invalid_ship_escrow.rs
+  - update_ship.rs
+  - invalidate_ship.rs
+- **Composite accounts**:
+  - `StarbaseMutAndStarbasePlayer`
+  - `GameAndGameStateAndProfile`
+- **Complexity**: Medium
+- **Priority**: 🟡 Medium
+- **Status**: 🔲 Pending
+
+#### Patch 12: Rental System
+- **Files**: ~3
+  - add_rental.rs
+  - change_rental.rs
+  - invalidate_rental.rs
+- **Composite accounts**:
+  - `StarbaseMutAndStarbasePlayer`
+- **Complexity**: Low-Medium
+- **Priority**: 🟡 Medium
+- **Status**: 🔲 Pending
+
+---
+
+### Priority 3: Admin & Configuration (Lower Priority)
+
+#### Patch 13: Admin - Game Registration & Config
+- **Files**: ~13
+- **Functional areas**:
+  - Game: init_game, init_game_state, update_game, update_game_state, activate_game_state, copy_game_state
+  - Ship: register_ship
+  - Crew: register_sage_crew_config
+  - Player: register_sage_player_profile, register_sage_point_modifier
+  - Progression: register_progression_config, update_progression_config, deregister_progression_config
+- **Composite accounts**:
+  - `GameAndProfile`
+  - `GameAccounts`
+- **Complexity**: Low-Medium
+- **Priority**: 🟢 Low - Admin functions, less frequently called
+- **Status**: 🔲 Pending
+
+#### Patch 14: Admin - Starbase & Sector Config
+- **Files**: ~10
+- **Functional areas**:
+  - Starbase: register_starbase, update_starbase, deregister_starbase
+  - Sector: register_sector, add_connection, remove_connection
+  - Celestial: register_planet, update_planet, register_star, update_star
+- **Composite accounts**:
+  - `GameAndProfile`
+  - `GameStateAndProfile`
+- **Complexity**: Low-Medium
+- **Priority**: 🟢 Low - Admin functions
+- **Status**: 🔲 Pending
+
+#### Patch 15: Admin - Resources & Mining Config
+- **Files**: ~11
+- **Functional areas**:
+  - Resources: register_resource, update_resource, deregister_resource
+  - Mine items: register_mine_item, update_mine_item, deregister_mine_item, drain_mine_item_bank
+  - Survey units: register_survey_data_unit_tracker, update_survey_data_unit_tracker, deregister_survey_data_unit_tracker, drain_survey_data_units_bank
+- **Composite accounts**:
+  - `GameAndProfile`
+  - `GameAccounts`
+- **Complexity**: Low-Medium
+- **Priority**: 🟢 Low - Admin functions
+- **Status**: 🔲 Pending
+
+#### Patch 16: Certificates & Miscellaneous
+- **Files**: ~3
+  - create_certificate_mint.rs
+  - mint_certificate.rs
+  - redeem_certificate.rs
+- **Composite accounts**:
+  - `GameAndProfile`
+- **Complexity**: Low
+- **Priority**: 🟢 Low
+- **Status**: 🔲 Pending
+
+---
+
+## Common Composite Account Patterns
+
+### Pattern 1: GameAndGameStateAndFleetAndOwnerMut
+**Expands to** (5 accounts):
+- `fleet_and_owner` → fleet, fleet_owner_profile
+- `game_id`
+- `game_state`
+- `game_account` (sometimes called `key`)
+
+### Pattern 2: StarbaseMutAndStarbasePlayer
+**Expands to** (2 accounts):
+- `starbase`
+- `starbase_player`
+
+### Pattern 3: GameAndGameStateAndProfile
+**Expands to** (5 accounts):
+- `key`
+- `profile`
+- `profile_faction`
+- `game_id`
+- `game_state`
+
+### Pattern 4: GameAndGameState
+**Expands to** (2 accounts):
+- `game_id`
+- `game_state`
+
+### Pattern 5: PointsModificationAccounts
+**Expands to** (3 accounts per instance):
+- `user_points_account`
+- `points_category`
+- `points_modifier_account`
+
+---
+
+## Execution Strategy
+
+### Recommended Order
+1. **Patch 06** - Fleet Operations (core gameplay)
+2. **Patch 07** - Fleet Cargo (frequently used)
+3. **Patch 11** - Scanning & Discovery (core gameplay with XP)
+4. **Patch 08** - Starbase Cargo (frequently used)
+5. **Patch 09** - Crew Management
+6. **Patch 10** - Ship Escrow
+7. **Patch 12** - Rental System
+8. **Patch 13** - Game Config (admin)
+9. **Patch 14** - Starbase Config (admin)
+10. **Patch 15** - Resources Config (admin)
+11. **Patch 16** - Certificates
+
+### Workflow Per Patch
+1. `just build-sage-starbased` - Clean build
+2. `just apply-patches-sage-starbased` - Apply existing patches
+3. `cd dist/sage-starbased && git add -A && git commit -m "Apply existing patches"` - Commit to isolate new changes
+4. Edit instruction files with composite account expansions
+5. `cargo check` - Test compilation
+6. `just create-patch-sage-starbased XX-descriptive-name` - Create patch
+7. `just publish-sage-starbased` - Publish to workspace (optional)
+
+---
+
+## Files Not Requiring Patches
+These files appear to use only direct accounts (no composite expansions needed):
+- close_disbanded_fleet.rs
+- close_player_crew_record.rs
+- force_drop_fleet_cargo.rs
+- set_next_ship.rs
+- init_game.rs
+- register_sage_player_profile.rs
+
+**Total**: ~6 files
+
+---
+
+## Notes
+- All patches follow the established comment pattern from patches 02-05
+- Comment format: `// CompositeAccountName expansion` followed by individual accounts
+- Direct accounts are marked with `// Direct accounts` comment
+- Account order must match the Solana program's account ordering exactly
+- XP account expansions (PointsModificationAccounts) follow the same 3-field pattern

--- a/patches/sage-starbased-06-instructions-fleet.patch
+++ b/patches/sage-starbased-06-instructions-fleet.patch
@@ -1,0 +1,805 @@
+diff --git a/src/instructions/add_ship_to_fleet.rs b/src/instructions/add_ship_to_fleet.rs
+index d7909ce..3324504 100644
+--- a/src/instructions/add_ship_to_fleet.rs
++++ b/src/instructions/add_ship_to_fleet.rs
+@@ -12,11 +12,21 @@ pub struct AddShipToFleet {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct AddShipToFleetInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub funder: solana_pubkey::Pubkey,
+     pub fleet_ships: solana_pubkey::Pubkey,
+     pub ship: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub system_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -27,19 +37,35 @@ impl carbon_core::deserialize::ArrangeAccounts for AddShipToFleet {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let funder = next_account(&mut iter)?;
+         let fleet_ships = next_account(&mut iter)?;
+         let ship = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(AddShipToFleetInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             funder,
+             fleet_ships,
+             ship,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             system_program,
+         })
+     }
+diff --git a/src/instructions/close_fleet_cargo_pod_token_account.rs b/src/instructions/close_fleet_cargo_pod_token_account.rs
+index b395d37..90df8b5 100644
+--- a/src/instructions/close_fleet_cargo_pod_token_account.rs
++++ b/src/instructions/close_fleet_cargo_pod_token_account.rs
+@@ -12,7 +12,14 @@ pub struct CloseFleetCargoPodTokenAccount {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CloseFleetCargoPodTokenAccountInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub cargo_pod: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+@@ -30,7 +37,14 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseFleetCargoPodTokenAccoun
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let cargo_pod = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+@@ -41,7 +55,12 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseFleetCargoPodTokenAccoun
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(CloseFleetCargoPodTokenAccountInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             cargo_pod,
+             cargo_type,
+             cargo_stats_definition,
+diff --git a/src/instructions/create_fleet.rs b/src/instructions/create_fleet.rs
+index 6f6c053..db45529 100644
+--- a/src/instructions/create_fleet.rs
++++ b/src/instructions/create_fleet.rs
+@@ -12,7 +12,11 @@ pub struct CreateFleet {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CreateFleetInstructionAccounts {
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub funder: solana_pubkey::Pubkey,
+     pub fleet: solana_pubkey::Pubkey,
+     pub fleet_ships: solana_pubkey::Pubkey,
+@@ -20,7 +24,10 @@ pub struct CreateFleetInstructionAccounts {
+     pub fuel_tank: solana_pubkey::Pubkey,
+     pub ammo_bank: solana_pubkey::Pubkey,
+     pub ship: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+     pub cargo_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+@@ -33,7 +40,11 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateFleet {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++        // GameAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        // Direct accounts
+         let funder = next_account(&mut iter)?;
+         let fleet = next_account(&mut iter)?;
+         let fleet_ships = next_account(&mut iter)?;
+@@ -41,13 +52,18 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateFleet {
+         let fuel_tank = next_account(&mut iter)?;
+         let ammo_bank = next_account(&mut iter)?;
+         let ship = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let cargo_stats_definition = next_account(&mut iter)?;
+         let cargo_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(CreateFleetInstructionAccounts {
+-            game_accounts_and_profile,
++            key,
++            profile,
++            game_id,
+             funder,
+             fleet,
+             fleet_ships,
+@@ -55,7 +71,8 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateFleet {
+             fuel_tank,
+             ammo_bank,
+             ship,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             cargo_stats_definition,
+             cargo_program,
+             system_program,
+diff --git a/src/instructions/disband_fleet.rs b/src/instructions/disband_fleet.rs
+index 2b88f2e..ccf5aad 100644
+--- a/src/instructions/disband_fleet.rs
++++ b/src/instructions/disband_fleet.rs
+@@ -12,7 +12,11 @@ pub struct DisbandFleet {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct DisbandFleetInstructionAccounts {
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub funder: solana_pubkey::Pubkey,
+     pub disbanded_fleet: solana_pubkey::Pubkey,
+     pub fleet: solana_pubkey::Pubkey,
+@@ -20,7 +24,10 @@ pub struct DisbandFleetInstructionAccounts {
+     pub cargo_hold: solana_pubkey::Pubkey,
+     pub fuel_tank: solana_pubkey::Pubkey,
+     pub ammo_bank: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub cargo_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -32,7 +39,11 @@ impl carbon_core::deserialize::ArrangeAccounts for DisbandFleet {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++        // GameAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        // Direct accounts
+         let funder = next_account(&mut iter)?;
+         let disbanded_fleet = next_account(&mut iter)?;
+         let fleet = next_account(&mut iter)?;
+@@ -40,12 +51,17 @@ impl carbon_core::deserialize::ArrangeAccounts for DisbandFleet {
+         let cargo_hold = next_account(&mut iter)?;
+         let fuel_tank = next_account(&mut iter)?;
+         let ammo_bank = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let cargo_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(DisbandFleetInstructionAccounts {
+-            game_accounts_and_profile,
++            key,
++            profile,
++            game_id,
+             funder,
+             disbanded_fleet,
+             fleet,
+@@ -53,7 +69,8 @@ impl carbon_core::deserialize::ArrangeAccounts for DisbandFleet {
+             cargo_hold,
+             fuel_tank,
+             ammo_bank,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             cargo_program,
+             system_program,
+         })
+diff --git a/src/instructions/disbanded_fleet_to_escrow.rs b/src/instructions/disbanded_fleet_to_escrow.rs
+index d0622ec..8b772b3 100644
+--- a/src/instructions/disbanded_fleet_to_escrow.rs
++++ b/src/instructions/disbanded_fleet_to_escrow.rs
+@@ -12,11 +12,18 @@ pub struct DisbandedFleetToEscrow {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct DisbandedFleetToEscrowInstructionAccounts {
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub funder: solana_pubkey::Pubkey,
+     pub disbanded_fleet: solana_pubkey::Pubkey,
+     pub fleet_ships: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub ship: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -28,20 +35,30 @@ impl carbon_core::deserialize::ArrangeAccounts for DisbandedFleetToEscrow {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++        // GameAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        // Direct accounts
+         let funder = next_account(&mut iter)?;
+         let disbanded_fleet = next_account(&mut iter)?;
+         let fleet_ships = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let ship = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(DisbandedFleetToEscrowInstructionAccounts {
+-            game_accounts_and_profile,
++            key,
++            profile,
++            game_id,
+             funder,
+             disbanded_fleet,
+             fleet_ships,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             ship,
+             system_program,
+         })
+diff --git a/src/instructions/force_disband_fleet.rs b/src/instructions/force_disband_fleet.rs
+index 4f063f9..842946a 100644
+--- a/src/instructions/force_disband_fleet.rs
++++ b/src/instructions/force_disband_fleet.rs
+@@ -12,6 +12,7 @@ pub struct ForceDisbandFleet {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct ForceDisbandFleetInstructionAccounts {
++    // Direct accounts
+     pub funder: solana_pubkey::Pubkey,
+     pub disbanded_fleet: solana_pubkey::Pubkey,
+     pub fleet: solana_pubkey::Pubkey,
+@@ -19,9 +20,15 @@ pub struct ForceDisbandFleetInstructionAccounts {
+     pub cargo_hold: solana_pubkey::Pubkey,
+     pub fuel_tank: solana_pubkey::Pubkey,
+     pub ammo_bank: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub ship: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub cargo_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -33,6 +40,7 @@ impl carbon_core::deserialize::ArrangeAccounts for ForceDisbandFleet {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
++        // Direct accounts
+         let funder = next_account(&mut iter)?;
+         let disbanded_fleet = next_account(&mut iter)?;
+         let fleet = next_account(&mut iter)?;
+@@ -40,9 +48,15 @@ impl carbon_core::deserialize::ArrangeAccounts for ForceDisbandFleet {
+         let cargo_hold = next_account(&mut iter)?;
+         let fuel_tank = next_account(&mut iter)?;
+         let ammo_bank = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let ship = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let cargo_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+@@ -54,9 +68,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ForceDisbandFleet {
+             cargo_hold,
+             fuel_tank,
+             ammo_bank,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             ship,
+-            game_accounts,
++            game_id,
++            game_state,
+             cargo_program,
+             system_program,
+         })
+diff --git a/src/instructions/idle_to_loading_bay.rs b/src/instructions/idle_to_loading_bay.rs
+index 3cb80ac..d0da373 100644
+--- a/src/instructions/idle_to_loading_bay.rs
++++ b/src/instructions/idle_to_loading_bay.rs
+@@ -10,8 +10,16 @@ pub struct IdleToLoadingBay {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct IdleToLoadingBayInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+ }
+ 
+ impl carbon_core::deserialize::ArrangeAccounts for IdleToLoadingBay {
+@@ -21,12 +29,26 @@ impl carbon_core::deserialize::ArrangeAccounts for IdleToLoadingBay {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
+ 
+         Some(IdleToLoadingBayInstructionAccounts {
+-            game_accounts_fleet_and_owner,
+-            starbase_and_starbase_player,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
++            starbase,
++            starbase_player,
+         })
+     }
+ }
+diff --git a/src/instructions/idle_to_respawn.rs b/src/instructions/idle_to_respawn.rs
+index 69ae6f1..13fa8de 100644
+--- a/src/instructions/idle_to_respawn.rs
++++ b/src/instructions/idle_to_respawn.rs
+@@ -12,7 +12,14 @@ pub struct IdleToRespawn {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct IdleToRespawnInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub atlas_token_from: solana_pubkey::Pubkey,
+     pub atlas_token_to: solana_pubkey::Pubkey,
+     pub token_program: solana_pubkey::Pubkey,
+@@ -25,13 +32,25 @@ impl carbon_core::deserialize::ArrangeAccounts for IdleToRespawn {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let atlas_token_from = next_account(&mut iter)?;
+         let atlas_token_to = next_account(&mut iter)?;
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(IdleToRespawnInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             atlas_token_from,
+             atlas_token_to,
+             token_program,
+diff --git a/src/instructions/load_fleet_crew.rs b/src/instructions/load_fleet_crew.rs
+index 03e6d7a..af0a0f5 100644
+--- a/src/instructions/load_fleet_crew.rs
++++ b/src/instructions/load_fleet_crew.rs
+@@ -12,8 +12,15 @@ pub struct LoadFleetCrew {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct LoadFleetCrewInstructionAccounts {
+-    pub fleet_and_owner: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // FleetAndOwner expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub game_id: solana_pubkey::Pubkey,
+ }
+ 
+@@ -24,13 +31,24 @@ impl carbon_core::deserialize::ArrangeAccounts for LoadFleetCrew {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let fleet_and_owner = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // FleetAndOwner expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let game_id = next_account(&mut iter)?;
+ 
+         Some(LoadFleetCrewInstructionAccounts {
+-            fleet_and_owner,
+-            starbase_and_starbase_player,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            starbase,
++            starbase_player,
+             game_id,
+         })
+     }
+diff --git a/src/instructions/loading_bay_to_idle.rs b/src/instructions/loading_bay_to_idle.rs
+index e202fbe..8545795 100644
+--- a/src/instructions/loading_bay_to_idle.rs
++++ b/src/instructions/loading_bay_to_idle.rs
+@@ -10,8 +10,16 @@ pub struct LoadingBayToIdle {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct LoadingBayToIdleInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+ }
+ 
+ impl carbon_core::deserialize::ArrangeAccounts for LoadingBayToIdle {
+@@ -21,12 +29,26 @@ impl carbon_core::deserialize::ArrangeAccounts for LoadingBayToIdle {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
+ 
+         Some(LoadingBayToIdleInstructionAccounts {
+-            game_accounts_fleet_and_owner,
+-            starbase_and_starbase_player,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
++            starbase,
++            starbase_player,
+         })
+     }
+ }
+diff --git a/src/instructions/mine_asteroid_to_respawn.rs b/src/instructions/mine_asteroid_to_respawn.rs
+index d6779d2..045d04e 100644
+--- a/src/instructions/mine_asteroid_to_respawn.rs
++++ b/src/instructions/mine_asteroid_to_respawn.rs
+@@ -12,7 +12,14 @@ pub struct MineAsteroidToRespawn {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct MineAsteroidToRespawnInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub resource: solana_pubkey::Pubkey,
+     pub planet: solana_pubkey::Pubkey,
+     pub atlas_token_from: solana_pubkey::Pubkey,
+@@ -27,7 +34,14 @@ impl carbon_core::deserialize::ArrangeAccounts for MineAsteroidToRespawn {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // Direct accounts
+         let resource = next_account(&mut iter)?;
+         let planet = next_account(&mut iter)?;
+         let atlas_token_from = next_account(&mut iter)?;
+@@ -35,7 +49,12 @@ impl carbon_core::deserialize::ArrangeAccounts for MineAsteroidToRespawn {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(MineAsteroidToRespawnInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             resource,
+             planet,
+             atlas_token_from,
+diff --git a/src/instructions/respawn_to_loading_bay.rs b/src/instructions/respawn_to_loading_bay.rs
+index 220f58d..6b68f08 100644
+--- a/src/instructions/respawn_to_loading_bay.rs
++++ b/src/instructions/respawn_to_loading_bay.rs
+@@ -12,8 +12,17 @@ pub struct RespawnToLoadingBay {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct RespawnToLoadingBayInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub cargo_hold: solana_pubkey::Pubkey,
+     pub fuel_tank: solana_pubkey::Pubkey,
+     pub ammo_bank: solana_pubkey::Pubkey,
+@@ -26,15 +35,30 @@ impl carbon_core::deserialize::ArrangeAccounts for RespawnToLoadingBay {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let cargo_hold = next_account(&mut iter)?;
+         let fuel_tank = next_account(&mut iter)?;
+         let ammo_bank = next_account(&mut iter)?;
+ 
+         Some(RespawnToLoadingBayInstructionAccounts {
+-            game_accounts_fleet_and_owner,
+-            starbase_and_starbase_player,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
++            starbase,
++            starbase_player,
+             cargo_hold,
+             fuel_tank,
+             ammo_bank,
+diff --git a/src/instructions/unload_fleet_crew.rs b/src/instructions/unload_fleet_crew.rs
+index cd346c9..496910d 100644
+--- a/src/instructions/unload_fleet_crew.rs
++++ b/src/instructions/unload_fleet_crew.rs
+@@ -12,8 +12,15 @@ pub struct UnloadFleetCrew {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct UnloadFleetCrewInstructionAccounts {
+-    pub fleet_and_owner: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // FleetAndOwner expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub game_id: solana_pubkey::Pubkey,
+ }
+ 
+@@ -24,13 +31,24 @@ impl carbon_core::deserialize::ArrangeAccounts for UnloadFleetCrew {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let fleet_and_owner = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++        // FleetAndOwner expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++        // Direct accounts
+         let game_id = next_account(&mut iter)?;
+ 
+         Some(UnloadFleetCrewInstructionAccounts {
+-            fleet_and_owner,
+-            starbase_and_starbase_player,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            starbase,
++            starbase_player,
+             game_id,
+         })
+     }
+diff --git a/src/instructions/update_ship_in_fleet.rs b/src/instructions/update_ship_in_fleet.rs
+index d9ee076..c01d66c 100644
+--- a/src/instructions/update_ship_in_fleet.rs
++++ b/src/instructions/update_ship_in_fleet.rs
+@@ -12,11 +12,14 @@ pub struct UpdateShipInFleet {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct UpdateShipInFleetInstructionAccounts {
++    // Direct accounts
+     pub fleet: solana_pubkey::Pubkey,
+     pub fleet_ships: solana_pubkey::Pubkey,
+     pub old_ship: solana_pubkey::Pubkey,
+     pub next: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+ }
+ 
+ impl carbon_core::deserialize::ArrangeAccounts for UpdateShipInFleet {
+@@ -26,18 +29,22 @@ impl carbon_core::deserialize::ArrangeAccounts for UpdateShipInFleet {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
++        // Direct accounts
+         let fleet = next_account(&mut iter)?;
+         let fleet_ships = next_account(&mut iter)?;
+         let old_ship = next_account(&mut iter)?;
+         let next = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
+ 
+         Some(UpdateShipInFleetInstructionAccounts {
+             fleet,
+             fleet_ships,
+             old_ship,
+             next,
+-            game_accounts,
++            game_id,
++            game_state,
+         })
+     }
+ }


### PR DESCRIPTION
# Sage Starbased Decoder: Fleet Operations Account Expansion

### TL;DR

Expands composite accounts in fleet operation instructions to match the actual Solana program structure.

### What changed?

This PR adds a comprehensive patching plan document and implements Patch 06 for fleet operations and state transitions. The patch expands composite accounts in 15 fleet-related instruction files:

- Core fleet management: `create_fleet.rs`, `add_ship_to_fleet.rs`, `disband_fleet.rs`, etc.
- Fleet state transitions: `idle_to_loading_bay.rs`, `loading_bay_to_idle.rs`, `respawn_to_loading_bay.rs`, etc.
- Fleet cargo operations: `close_fleet_cargo_pod_token_account.rs`
- Ship management: `update_ship_in_fleet.rs`

Key composite account patterns expanded:
- `GameAndGameStateAndFleetAndOwnerMut` → key, owning_profile, owning_profile_faction, fleet, game_id, game_state
- `FleetAndOwner` → key, owning_profile, owning_profile_faction, fleet
- `StarbaseMutAndStarbasePlayer` → starbase, starbase_player
- `GameAndGameState` → game_id, game_state

### How to test?

1. Build the decoder with `just build-sage-starbased`
2. Apply the patches with `just apply-patches-sage-starbased`
3. Verify the decoder correctly parses fleet operations transactions

### Why make this change?

This change is part of a larger effort to make the decoder match the actual Solana program structure. By expanding composite accounts, the decoder can properly identify and display all accounts involved in fleet operations, improving transaction readability and debugging capabilities.