### PR TITLE
feat: sage-starbased patch 07 instructions cargo

### DIFF
--- a/carbon-decoders/sage-starbased-decoder/src/instructions/deposit_cargo_to_fleet.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/deposit_cargo_to_fleet.rs
@@ -12,9 +12,19 @@ pub struct DepositCargoToFleet {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DepositCargoToFleetInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub funds_to: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub cargo_pod_from: solana_pubkey::Pubkey,
     pub cargo_pod_to: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
@@ -33,9 +43,23 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCargoToFleet {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // Direct accounts
         let funds_to = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
+        // Direct accounts
         let cargo_pod_from = next_account(&mut iter)?;
         let cargo_pod_to = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
@@ -47,9 +71,15 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCargoToFleet {
         let token_program = next_account(&mut iter)?;
 
         Some(DepositCargoToFleetInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             funds_to,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             cargo_pod_from,
             cargo_pod_to,
             cargo_type,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/set_next_ship.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/set_next_ship.rs
@@ -10,7 +10,11 @@ pub struct SetNextShip {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SetNextShipInstructionAccounts {
-    pub game_and_profile: solana_pubkey::Pubkey,
+    // ActiveOrInactiveGameAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    // Direct accounts
     pub ship: solana_pubkey::Pubkey,
     pub next_ship: solana_pubkey::Pubkey,
 }
@@ -22,12 +26,20 @@ impl carbon_core::deserialize::ArrangeAccounts for SetNextShip {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_and_profile = next_account(&mut iter)?;
+
+        // ActiveOrInactiveGameAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+
+        // Direct accounts
         let ship = next_account(&mut iter)?;
         let next_ship = next_account(&mut iter)?;
 
         Some(SetNextShipInstructionAccounts {
-            game_and_profile,
+            key,
+            profile,
+            game_id,
             ship,
             next_ship,
         })

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/transfer_cargo_within_fleet.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/transfer_cargo_within_fleet.rs
@@ -12,7 +12,14 @@ pub struct TransferCargoWithinFleet {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct TransferCargoWithinFleetInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // Direct accounts
     pub cargo_pod_from: solana_pubkey::Pubkey,
     pub cargo_pod_to: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
@@ -32,7 +39,16 @@ impl carbon_core::deserialize::ArrangeAccounts for TransferCargoWithinFleet {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // Direct accounts
         let cargo_pod_from = next_account(&mut iter)?;
         let cargo_pod_to = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
@@ -45,7 +61,12 @@ impl carbon_core::deserialize::ArrangeAccounts for TransferCargoWithinFleet {
         let token_program = next_account(&mut iter)?;
 
         Some(TransferCargoWithinFleetInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             cargo_pod_from,
             cargo_pod_to,
             cargo_type,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/withdraw_cargo_from_fleet.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/withdraw_cargo_from_fleet.rs
@@ -12,8 +12,17 @@ pub struct WithdrawCargoFromFleet {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct WithdrawCargoFromFleetInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // Direct accounts
     pub cargo_pod_from: solana_pubkey::Pubkey,
     pub cargo_pod_to: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
@@ -33,8 +42,20 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCargoFromFleet {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
+        // Direct accounts
         let cargo_pod_from = next_account(&mut iter)?;
         let cargo_pod_to = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
@@ -47,8 +68,14 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCargoFromFleet {
         let token_program = next_account(&mut iter)?;
 
         Some(WithdrawCargoFromFleetInstructionAccounts {
-            game_accounts_fleet_and_owner,
-            starbase_and_starbase_player,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
+            starbase,
+            starbase_player,
             cargo_pod_from,
             cargo_pod_to,
             cargo_type,

--- a/docs/sage-starbased-patching-plan.md
+++ b/docs/sage-starbased-patching-plan.md
@@ -5,11 +5,11 @@ This document outlines the complete patching strategy for expanding composite ac
 
 ## Progress Summary
 - **Total instruction files**: 106
-- **Completed patches**: 6 (covering 38 files)
-- **Remaining patches**: 10 (covering 68 files)
+- **Completed patches**: 7 (covering 42 files)
+- **Remaining patches**: 9 (covering 64 files)
 - **Estimated total patches**: 16
 
-## Completed Patches (01-05)
+## Completed Patches (01-07)
 
 ### Patch 01: Accounts
 - **Files**: 1 (fleet.rs)
@@ -66,13 +66,7 @@ This document outlines the complete patching strategy for expanding composite ac
   - `PointsModificationAccounts` (in close_crafting_process.rs)
 - **Status**: ✅ Complete
 
----
-
-## Remaining Patches (06-16)
-
-### Priority 1: Core Gameplay (High Priority)
-
-#### Patch 06: Fleet Operations & State Transitions
+### Patch 06: Fleet Operations & State Transitions
 - **Files**: 15
   - create_fleet.rs
   - add_ship_to_fleet.rs
@@ -98,18 +92,25 @@ This document outlines the complete patching strategy for expanding composite ac
 - **Priority**: 🔴 High - Core fleet functionality
 - **Status**: ✅ Complete (805 lines)
 
-#### Patch 07: Fleet Cargo Operations
-- **Files**: ~4
+### Patch 07: Fleet Cargo Operations
+- **Files**: 4
   - deposit_cargo_to_fleet.rs
   - withdraw_cargo_from_fleet.rs
   - transfer_cargo_within_fleet.rs
   - set_next_ship.rs
 - **Composite accounts**:
-  - `GameAndGameStateAndFleetAndOwnerMut`
-  - `StarbaseMutAndStarbasePlayer`
+  - `GameAndGameStateAndFleetAndOwnerMut` → key, owning_profile, owning_profile_faction, fleet, game_id, game_state
+  - `StarbaseAndStarbasePlayer` → starbase, starbase_player (deposit & withdraw only)
+  - `ActiveOrInactiveGameAndProfile` → key, profile, game_id (set_next_ship only)
 - **Complexity**: Medium
 - **Priority**: 🔴 High - Frequently used operations
-- **Status**: 🔲 Pending
+- **Status**: ✅ Complete (226 lines)
+
+---
+
+## Remaining Patches (08-16)
+
+### Priority 1: Core Gameplay (High Priority)
 
 #### Patch 11: Scanning & Discovery
 - **Files**: ~3
@@ -276,9 +277,9 @@ This document outlines the complete patching strategy for expanding composite ac
 ## Execution Strategy
 
 ### Recommended Order
-1. **Patch 06** - Fleet Operations (core gameplay)
-2. **Patch 07** - Fleet Cargo (frequently used)
-3. **Patch 11** - Scanning & Discovery (core gameplay with XP)
+1. ~~**Patch 06** - Fleet Operations (core gameplay)~~ ✅ Complete
+2. ~~**Patch 07** - Fleet Cargo (frequently used)~~ ✅ Complete
+3. **Patch 11** - Scanning & Discovery (core gameplay with XP) - **NEXT**
 4. **Patch 08** - Starbase Cargo (frequently used)
 5. **Patch 09** - Crew Management
 6. **Patch 10** - Ship Escrow
@@ -304,11 +305,10 @@ These files appear to use only direct accounts (no composite expansions needed):
 - close_disbanded_fleet.rs
 - close_player_crew_record.rs
 - force_drop_fleet_cargo.rs
-- set_next_ship.rs
 - init_game.rs
 - register_sage_player_profile.rs
 
-**Total**: ~6 files
+**Total**: ~5 files
 
 ---
 

--- a/patches/sage-starbased-07-instructions-cargo.patch
+++ b/patches/sage-starbased-07-instructions-cargo.patch
@@ -1,0 +1,226 @@
+diff --git a/src/instructions/deposit_cargo_to_fleet.rs b/src/instructions/deposit_cargo_to_fleet.rs
+index 1fc6d43..1d94089 100644
+--- a/src/instructions/deposit_cargo_to_fleet.rs
++++ b/src/instructions/deposit_cargo_to_fleet.rs
+@@ -12,9 +12,19 @@ pub struct DepositCargoToFleet {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct DepositCargoToFleetInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub funds_to: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub cargo_pod_from: solana_pubkey::Pubkey,
+     pub cargo_pod_to: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+@@ -33,9 +43,23 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCargoToFleet {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // Direct accounts
+         let funds_to = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
++        // Direct accounts
+         let cargo_pod_from = next_account(&mut iter)?;
+         let cargo_pod_to = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+@@ -47,9 +71,15 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCargoToFleet {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(DepositCargoToFleetInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             funds_to,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             cargo_pod_from,
+             cargo_pod_to,
+             cargo_type,
+diff --git a/src/instructions/set_next_ship.rs b/src/instructions/set_next_ship.rs
+index 85278fc..28ec0ed 100644
+--- a/src/instructions/set_next_ship.rs
++++ b/src/instructions/set_next_ship.rs
+@@ -10,7 +10,11 @@ pub struct SetNextShip {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct SetNextShipInstructionAccounts {
+-    pub game_and_profile: solana_pubkey::Pubkey,
++    // ActiveOrInactiveGameAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub ship: solana_pubkey::Pubkey,
+     pub next_ship: solana_pubkey::Pubkey,
+ }
+@@ -22,12 +26,20 @@ impl carbon_core::deserialize::ArrangeAccounts for SetNextShip {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_and_profile = next_account(&mut iter)?;
++
++        // ActiveOrInactiveGameAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++
++        // Direct accounts
+         let ship = next_account(&mut iter)?;
+         let next_ship = next_account(&mut iter)?;
+ 
+         Some(SetNextShipInstructionAccounts {
+-            game_and_profile,
++            key,
++            profile,
++            game_id,
+             ship,
+             next_ship,
+         })
+diff --git a/src/instructions/transfer_cargo_within_fleet.rs b/src/instructions/transfer_cargo_within_fleet.rs
+index 607a048..911d68c 100644
+--- a/src/instructions/transfer_cargo_within_fleet.rs
++++ b/src/instructions/transfer_cargo_within_fleet.rs
+@@ -12,7 +12,14 @@ pub struct TransferCargoWithinFleet {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct TransferCargoWithinFleetInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub cargo_pod_from: solana_pubkey::Pubkey,
+     pub cargo_pod_to: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+@@ -32,7 +39,16 @@ impl carbon_core::deserialize::ArrangeAccounts for TransferCargoWithinFleet {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // Direct accounts
+         let cargo_pod_from = next_account(&mut iter)?;
+         let cargo_pod_to = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+@@ -45,7 +61,12 @@ impl carbon_core::deserialize::ArrangeAccounts for TransferCargoWithinFleet {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(TransferCargoWithinFleetInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             cargo_pod_from,
+             cargo_pod_to,
+             cargo_type,
+diff --git a/src/instructions/withdraw_cargo_from_fleet.rs b/src/instructions/withdraw_cargo_from_fleet.rs
+index c21a5d6..d626eed 100644
+--- a/src/instructions/withdraw_cargo_from_fleet.rs
++++ b/src/instructions/withdraw_cargo_from_fleet.rs
+@@ -12,8 +12,17 @@ pub struct WithdrawCargoFromFleet {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct WithdrawCargoFromFleetInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // Direct accounts
+     pub cargo_pod_from: solana_pubkey::Pubkey,
+     pub cargo_pod_to: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+@@ -33,8 +42,20 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCargoFromFleet {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
++        // Direct accounts
+         let cargo_pod_from = next_account(&mut iter)?;
+         let cargo_pod_to = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+@@ -47,8 +68,14 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCargoFromFleet {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(WithdrawCargoFromFleetInstructionAccounts {
+-            game_accounts_fleet_and_owner,
+-            starbase_and_starbase_player,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
++            starbase,
++            starbase_player,
+             cargo_pod_from,
+             cargo_pod_to,
+             cargo_type,


### PR DESCRIPTION
### TL;DR

Expanded composite account structures in fleet cargo operations instructions to expose individual account fields.

### What changed?

This PR expands composite account structures in four fleet cargo operation instructions:
- `deposit_cargo_to_fleet.rs`: Expanded `GameAndGameStateAndFleetAndOwnerMut` and `StarbaseAndStarbasePlayer` into their individual account fields
- `withdraw_cargo_from_fleet.rs`: Same expansions as deposit
- `transfer_cargo_within_fleet.rs`: Expanded `GameAndGameStateAndFleetAndOwnerMut` into individual fields
- `set_next_ship.rs`: Expanded `ActiveOrInactiveGameAndProfile` into individual fields

Each composite account is now represented by its constituent fields with clear comments indicating the expansion boundaries.

### How to test?

1. Run the decoder against transactions that use these instructions
2. Verify that all account fields are properly decoded and accessible
3. Check that the expanded fields match the expected account structure

### Why make this change?

This change improves the decoder's ability to provide detailed information about the accounts involved in fleet cargo operations. By expanding composite accounts into their individual fields, we gain better visibility into the account structure and relationships, making it easier to analyze and debug transactions involving these operations.

This is part of the planned patching strategy for the sage-starbased-decoder, completing Patch 07 as outlined in the patching plan document.