### PR TITLE
feat: sage-starbased patch 10 instructions ship escrow

### DIFF
--- a/carbon-decoders/sage-starbased-decoder/src/instructions/add_ship_escrow.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/add_ship_escrow.rs
@@ -17,8 +17,15 @@ pub struct AddShipEscrowInstructionAccounts {
     pub origin_token_account: solana_pubkey::Pubkey,
     pub ship: solana_pubkey::Pubkey,
     pub ship_escrow_token_account: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayerMut expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
@@ -35,8 +42,18 @@ impl carbon_core::deserialize::ArrangeAccounts for AddShipEscrow {
         let origin_token_account = next_account(&mut iter)?;
         let ship = next_account(&mut iter)?;
         let ship_escrow_token_account = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayerMut expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let token_program = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
@@ -46,8 +63,13 @@ impl carbon_core::deserialize::ArrangeAccounts for AddShipEscrow {
             origin_token_account,
             ship,
             ship_escrow_token_account,
-            starbase_and_starbase_player,
-            game_accounts_and_profile,
+            starbase,
+            starbase_player,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             token_program,
             system_program,
         })

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/invalidate_ship.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/invalidate_ship.rs
@@ -10,7 +10,10 @@ pub struct InvalidateShip {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct InvalidateShipInstructionAccounts {
-    pub game_and_profile: solana_pubkey::Pubkey,
+    // ActiveOrInactiveGameAndProfileMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
     pub ship: solana_pubkey::Pubkey,
 }
 
@@ -21,11 +24,18 @@ impl carbon_core::deserialize::ArrangeAccounts for InvalidateShip {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_and_profile = next_account(&mut iter)?;
+
+        // ActiveOrInactiveGameAndProfileMut expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+
         let ship = next_account(&mut iter)?;
 
         Some(InvalidateShipInstructionAccounts {
-            game_and_profile,
+            key,
+            profile,
+            game_id,
             ship,
         })
     }

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/remove_invalid_ship_escrow.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/remove_invalid_ship_escrow.rs
@@ -12,13 +12,20 @@ pub struct RemoveInvalidShipEscrow {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct RemoveInvalidShipEscrowInstructionAccounts {
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub funds_to: solana_pubkey::Pubkey,
     pub sage_player_profile: solana_pubkey::Pubkey,
     pub destination_token_account: solana_pubkey::Pubkey,
     pub ship: solana_pubkey::Pubkey,
     pub ship_escrow_token_account: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayerMut expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
@@ -30,24 +37,40 @@ impl carbon_core::deserialize::ArrangeAccounts for RemoveInvalidShipEscrow {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let funds_to = next_account(&mut iter)?;
         let sage_player_profile = next_account(&mut iter)?;
         let destination_token_account = next_account(&mut iter)?;
         let ship = next_account(&mut iter)?;
         let ship_escrow_token_account = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayerMut expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let token_program = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
         Some(RemoveInvalidShipEscrowInstructionAccounts {
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             funds_to,
             sage_player_profile,
             destination_token_account,
             ship,
             ship_escrow_token_account,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             token_program,
             system_program,
         })

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/remove_ship_escrow.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/remove_ship_escrow.rs
@@ -12,13 +12,20 @@ pub struct RemoveShipEscrow {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct RemoveShipEscrowInstructionAccounts {
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub funds_to: solana_pubkey::Pubkey,
     pub sage_player_profile: solana_pubkey::Pubkey,
     pub destination_token_account: solana_pubkey::Pubkey,
     pub ship: solana_pubkey::Pubkey,
     pub ship_escrow_token_account: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayerMut expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
@@ -30,24 +37,40 @@ impl carbon_core::deserialize::ArrangeAccounts for RemoveShipEscrow {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let funds_to = next_account(&mut iter)?;
         let sage_player_profile = next_account(&mut iter)?;
         let destination_token_account = next_account(&mut iter)?;
         let ship = next_account(&mut iter)?;
         let ship_escrow_token_account = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayerMut expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let token_program = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
         Some(RemoveShipEscrowInstructionAccounts {
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             funds_to,
             sage_player_profile,
             destination_token_account,
             ship,
             ship_escrow_token_account,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             token_program,
             system_program,
         })

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/update_ship.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/update_ship.rs
@@ -12,7 +12,10 @@ pub struct UpdateShip {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct UpdateShipInstructionAccounts {
-    pub game_and_profile: solana_pubkey::Pubkey,
+    // ActiveOrInactiveGameAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
     pub ship: solana_pubkey::Pubkey,
 }
 
@@ -23,11 +26,18 @@ impl carbon_core::deserialize::ArrangeAccounts for UpdateShip {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_and_profile = next_account(&mut iter)?;
+
+        // ActiveOrInactiveGameAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+
         let ship = next_account(&mut iter)?;
 
         Some(UpdateShipInstructionAccounts {
-            game_and_profile,
+            key,
+            profile,
+            game_id,
             ship,
         })
     }

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/update_ship_escrow.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/update_ship_escrow.rs
@@ -14,8 +14,12 @@ pub struct UpdateShipEscrow {
 pub struct UpdateShipEscrowInstructionAccounts {
     pub old_ship: solana_pubkey::Pubkey,
     pub next: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
-    pub game_accounts: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayerMut expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
+    // GameAndGameState expansion
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for UpdateShipEscrow {
@@ -27,14 +31,22 @@ impl carbon_core::deserialize::ArrangeAccounts for UpdateShipEscrow {
         let mut iter = accounts.iter();
         let old_ship = next_account(&mut iter)?;
         let next = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
-        let game_accounts = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayerMut expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
+        // GameAndGameState expansion
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
 
         Some(UpdateShipEscrowInstructionAccounts {
             old_ship,
             next,
-            starbase_and_starbase_player,
-            game_accounts,
+            starbase,
+            starbase_player,
+            game_id,
+            game_state,
         })
     }
 }

--- a/docs/sage-starbased-patching-plan.md
+++ b/docs/sage-starbased-patching-plan.md
@@ -5,11 +5,11 @@ This document outlines the complete patching strategy for expanding composite ac
 
 ## Progress Summary
 - **Total instruction files**: 106
-- **Completed patches**: 9 (covering 56 files)
-- **Remaining patches**: 7 (covering 50 files)
+- **Completed patches**: 10 (covering 62 files)
+- **Remaining patches**: 6 (covering 44 files)
 - **Estimated total patches**: 16
 
-## Completed Patches (01-09)
+## Completed Patches (01-10)
 
 ### Patch 01: Accounts
 - **Files**: 1 (fleet.rs)
@@ -141,9 +141,26 @@ This document outlines the complete patching strategy for expanding composite ac
 - **Priority**: 🟡 Medium - Crew management operations
 - **Status**: ✅ Complete (242 lines)
 
+### Patch 10: Ship Escrow & Management
+- **Files**: 6
+  - add_ship_escrow.rs
+  - remove_ship_escrow.rs
+  - update_ship_escrow.rs
+  - remove_invalid_ship_escrow.rs
+  - update_ship.rs
+  - invalidate_ship.rs
+- **Composite accounts**:
+  - `StarbaseAndStarbasePlayerMut` → starbase, starbase_player
+  - `GameAndGameStateAndProfile` → key, profile, profile_faction, game_id, game_state
+  - `GameAndGameState` → game_id, game_state (update_ship_escrow only)
+  - `ActiveOrInactiveGameAndProfile` → key, profile, game_id (update_ship & invalidate_ship)
+- **Complexity**: Medium
+- **Priority**: 🟡 Medium - Ship escrow management operations
+- **Status**: ✅ Complete (323 lines)
+
 ---
 
-## Remaining Patches (10-16)
+## Remaining Patches (11-16)
 
 ### Priority 1: Core Gameplay (High Priority)
 
@@ -162,21 +179,6 @@ This document outlines the complete patching strategy for expanding composite ac
 ---
 
 ### Priority 2: Frequently Used Operations (Medium Priority)
-
-#### Patch 10: Ship Escrow & Management
-- **Files**: ~6
-  - add_ship_escrow.rs
-  - remove_ship_escrow.rs
-  - update_ship_escrow.rs
-  - remove_invalid_ship_escrow.rs
-  - update_ship.rs
-  - invalidate_ship.rs
-- **Composite accounts**:
-  - `StarbaseMutAndStarbasePlayer`
-  - `GameAndGameStateAndProfile`
-- **Complexity**: Medium
-- **Priority**: 🟡 Medium
-- **Status**: 🔲 Pending
 
 #### Patch 12: Rental System
 - **Files**: ~3

--- a/patches/sage-starbased-10-instructions-ship-escrow.patch
+++ b/patches/sage-starbased-10-instructions-ship-escrow.patch
@@ -1,0 +1,323 @@
+diff --git a/src/instructions/add_ship_escrow.rs b/src/instructions/add_ship_escrow.rs
+index e9efbc5..13f8aad 100644
+--- a/src/instructions/add_ship_escrow.rs
++++ b/src/instructions/add_ship_escrow.rs
+@@ -17,8 +17,15 @@ pub struct AddShipEscrowInstructionAccounts {
+     pub origin_token_account: solana_pubkey::Pubkey,
+     pub ship: solana_pubkey::Pubkey,
+     pub ship_escrow_token_account: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayerMut expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub token_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -35,8 +42,18 @@ impl carbon_core::deserialize::ArrangeAccounts for AddShipEscrow {
+         let origin_token_account = next_account(&mut iter)?;
+         let ship = next_account(&mut iter)?;
+         let ship_escrow_token_account = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayerMut expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let token_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+@@ -46,8 +63,13 @@ impl carbon_core::deserialize::ArrangeAccounts for AddShipEscrow {
+             origin_token_account,
+             ship,
+             ship_escrow_token_account,
+-            starbase_and_starbase_player,
+-            game_accounts_and_profile,
++            starbase,
++            starbase_player,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             token_program,
+             system_program,
+         })
+diff --git a/src/instructions/invalidate_ship.rs b/src/instructions/invalidate_ship.rs
+index 19e675d..0ed6453 100644
+--- a/src/instructions/invalidate_ship.rs
++++ b/src/instructions/invalidate_ship.rs
+@@ -10,7 +10,10 @@ pub struct InvalidateShip {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct InvalidateShipInstructionAccounts {
+-    pub game_and_profile: solana_pubkey::Pubkey,
++    // ActiveOrInactiveGameAndProfileMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
+     pub ship: solana_pubkey::Pubkey,
+ }
+ 
+@@ -21,11 +24,18 @@ impl carbon_core::deserialize::ArrangeAccounts for InvalidateShip {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_and_profile = next_account(&mut iter)?;
++
++        // ActiveOrInactiveGameAndProfileMut expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++
+         let ship = next_account(&mut iter)?;
+ 
+         Some(InvalidateShipInstructionAccounts {
+-            game_and_profile,
++            key,
++            profile,
++            game_id,
+             ship,
+         })
+     }
+diff --git a/src/instructions/remove_invalid_ship_escrow.rs b/src/instructions/remove_invalid_ship_escrow.rs
+index 42fe051..70737b5 100644
+--- a/src/instructions/remove_invalid_ship_escrow.rs
++++ b/src/instructions/remove_invalid_ship_escrow.rs
+@@ -12,13 +12,20 @@ pub struct RemoveInvalidShipEscrow {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct RemoveInvalidShipEscrowInstructionAccounts {
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub funds_to: solana_pubkey::Pubkey,
+     pub sage_player_profile: solana_pubkey::Pubkey,
+     pub destination_token_account: solana_pubkey::Pubkey,
+     pub ship: solana_pubkey::Pubkey,
+     pub ship_escrow_token_account: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayerMut expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub token_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -30,24 +37,40 @@ impl carbon_core::deserialize::ArrangeAccounts for RemoveInvalidShipEscrow {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let funds_to = next_account(&mut iter)?;
+         let sage_player_profile = next_account(&mut iter)?;
+         let destination_token_account = next_account(&mut iter)?;
+         let ship = next_account(&mut iter)?;
+         let ship_escrow_token_account = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayerMut expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let token_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(RemoveInvalidShipEscrowInstructionAccounts {
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             funds_to,
+             sage_player_profile,
+             destination_token_account,
+             ship,
+             ship_escrow_token_account,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             token_program,
+             system_program,
+         })
+diff --git a/src/instructions/remove_ship_escrow.rs b/src/instructions/remove_ship_escrow.rs
+index f9f0ddd..fc274f2 100644
+--- a/src/instructions/remove_ship_escrow.rs
++++ b/src/instructions/remove_ship_escrow.rs
+@@ -12,13 +12,20 @@ pub struct RemoveShipEscrow {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct RemoveShipEscrowInstructionAccounts {
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub funds_to: solana_pubkey::Pubkey,
+     pub sage_player_profile: solana_pubkey::Pubkey,
+     pub destination_token_account: solana_pubkey::Pubkey,
+     pub ship: solana_pubkey::Pubkey,
+     pub ship_escrow_token_account: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayerMut expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub token_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -30,24 +37,40 @@ impl carbon_core::deserialize::ArrangeAccounts for RemoveShipEscrow {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let funds_to = next_account(&mut iter)?;
+         let sage_player_profile = next_account(&mut iter)?;
+         let destination_token_account = next_account(&mut iter)?;
+         let ship = next_account(&mut iter)?;
+         let ship_escrow_token_account = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayerMut expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let token_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(RemoveShipEscrowInstructionAccounts {
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             funds_to,
+             sage_player_profile,
+             destination_token_account,
+             ship,
+             ship_escrow_token_account,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             token_program,
+             system_program,
+         })
+diff --git a/src/instructions/update_ship.rs b/src/instructions/update_ship.rs
+index e995885..8e8446e 100644
+--- a/src/instructions/update_ship.rs
++++ b/src/instructions/update_ship.rs
+@@ -12,7 +12,10 @@ pub struct UpdateShip {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct UpdateShipInstructionAccounts {
+-    pub game_and_profile: solana_pubkey::Pubkey,
++    // ActiveOrInactiveGameAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
+     pub ship: solana_pubkey::Pubkey,
+ }
+ 
+@@ -23,11 +26,18 @@ impl carbon_core::deserialize::ArrangeAccounts for UpdateShip {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_and_profile = next_account(&mut iter)?;
++
++        // ActiveOrInactiveGameAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++
+         let ship = next_account(&mut iter)?;
+ 
+         Some(UpdateShipInstructionAccounts {
+-            game_and_profile,
++            key,
++            profile,
++            game_id,
+             ship,
+         })
+     }
+diff --git a/src/instructions/update_ship_escrow.rs b/src/instructions/update_ship_escrow.rs
+index 4fa2292..86bf4f5 100644
+--- a/src/instructions/update_ship_escrow.rs
++++ b/src/instructions/update_ship_escrow.rs
+@@ -14,8 +14,12 @@ pub struct UpdateShipEscrow {
+ pub struct UpdateShipEscrowInstructionAccounts {
+     pub old_ship: solana_pubkey::Pubkey,
+     pub next: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayerMut expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+ }
+ 
+ impl carbon_core::deserialize::ArrangeAccounts for UpdateShipEscrow {
+@@ -27,14 +31,22 @@ impl carbon_core::deserialize::ArrangeAccounts for UpdateShipEscrow {
+         let mut iter = accounts.iter();
+         let old_ship = next_account(&mut iter)?;
+         let next = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayerMut expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
+ 
+         Some(UpdateShipEscrowInstructionAccounts {
+             old_ship,
+             next,
+-            starbase_and_starbase_player,
+-            game_accounts,
++            starbase,
++            starbase_player,
++            game_id,
++            game_state,
+         })
+     }
+ }


### PR DESCRIPTION
# Expanded Ship Escrow Account Structures

### TL;DR

Expanded composite account structures in ship escrow and management instructions to improve data visibility and debugging.

### What changed?

This PR expands several composite account structures in ship escrow and management-related instructions:

- Expanded `StarbaseAndStarbasePlayerMut` into individual `starbase` and `starbase_player` accounts
- Expanded `GameAndGameStateAndProfile` into `key`, `profile`, `profile_faction`, `game_id`, and `game_state`
- Expanded `GameAndGameState` into `game_id` and `game_state`
- Expanded `ActiveOrInactiveGameAndProfile` into `key`, `profile`, and `game_id`

The changes affect six instruction files:
- `add_ship_escrow.rs`
- `remove_ship_escrow.rs`
- `update_ship_escrow.rs`
- `remove_invalid_ship_escrow.rs`
- `update_ship.rs`
- `invalidate_ship.rs`

Also updated the patching plan document to reflect this completed work (Patch 10).

### How to test?

1. Run the decoder against transactions that use these ship escrow instructions
2. Verify that the expanded account structures are correctly populated
3. Ensure that all account fields are properly deserialized and accessible

### Why make this change?

This change improves debugging capabilities by making individual account fields directly accessible rather than bundled in composite structures. It provides better visibility into the account relationships and makes it easier to track account usage in ship escrow and management operations.