### PR TITLE
feat: sage-starbased patch 11 instructions scanning discovery

### DIFF
--- a/carbon-decoders/sage-starbased-decoder/src/instructions/discover_sector.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/discover_sector.rs
@@ -12,7 +12,13 @@ pub struct DiscoverSector {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DiscoverSectorInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwner expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub funder: solana_pubkey::Pubkey,
     pub sector: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
@@ -25,13 +31,26 @@ impl carbon_core::deserialize::ArrangeAccounts for DiscoverSector {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwner expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let funder = next_account(&mut iter)?;
         let sector = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
         Some(DiscoverSectorInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             funder,
             sector,
             system_program,

--- a/carbon-decoders/sage-starbased-decoder/src/instructions/scan_for_survey_data_units.rs
+++ b/carbon-decoders/sage-starbased-decoder/src/instructions/scan_for_survey_data_units.rs
@@ -12,7 +12,13 @@ pub struct ScanForSurveyDataUnits {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ScanForSurveyDataUnitsInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub survey_data_unit_tracker: solana_pubkey::Pubkey,
     pub survey_data_unit_tracker_signer: solana_pubkey::Pubkey,
     pub cargo_hold: solana_pubkey::Pubkey,
@@ -24,8 +30,14 @@ pub struct ScanForSurveyDataUnitsInstructionAccounts {
     pub sdu_cargo_type: solana_pubkey::Pubkey,
     pub resource_cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub data_running_xp_accounts: solana_pubkey::Pubkey,
-    pub council_rank_xp_accounts: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (data_running)
+    pub data_running_user_points_account: solana_pubkey::Pubkey,
+    pub data_running_points_category: solana_pubkey::Pubkey,
+    pub data_running_points_modifier_account: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (council_rank)
+    pub council_rank_user_points_account: solana_pubkey::Pubkey,
+    pub council_rank_points_category: solana_pubkey::Pubkey,
+    pub council_rank_points_modifier_account: solana_pubkey::Pubkey,
     pub progression_config: solana_pubkey::Pubkey,
     pub points_program: solana_pubkey::Pubkey,
     pub cargo_program: solana_pubkey::Pubkey,
@@ -41,7 +53,15 @@ impl carbon_core::deserialize::ArrangeAccounts for ScanForSurveyDataUnits {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let survey_data_unit_tracker = next_account(&mut iter)?;
         let survey_data_unit_tracker_signer = next_account(&mut iter)?;
         let cargo_hold = next_account(&mut iter)?;
@@ -53,8 +73,17 @@ impl carbon_core::deserialize::ArrangeAccounts for ScanForSurveyDataUnits {
         let sdu_cargo_type = next_account(&mut iter)?;
         let resource_cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let data_running_xp_accounts = next_account(&mut iter)?;
-        let council_rank_xp_accounts = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (data_running)
+        let data_running_user_points_account = next_account(&mut iter)?;
+        let data_running_points_category = next_account(&mut iter)?;
+        let data_running_points_modifier_account = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (council_rank)
+        let council_rank_user_points_account = next_account(&mut iter)?;
+        let council_rank_points_category = next_account(&mut iter)?;
+        let council_rank_points_modifier_account = next_account(&mut iter)?;
+
         let progression_config = next_account(&mut iter)?;
         let points_program = next_account(&mut iter)?;
         let cargo_program = next_account(&mut iter)?;
@@ -63,7 +92,12 @@ impl carbon_core::deserialize::ArrangeAccounts for ScanForSurveyDataUnits {
         let recent_slothashes = next_account(&mut iter)?;
 
         Some(ScanForSurveyDataUnitsInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             survey_data_unit_tracker,
             survey_data_unit_tracker_signer,
             cargo_hold,
@@ -75,8 +109,12 @@ impl carbon_core::deserialize::ArrangeAccounts for ScanForSurveyDataUnits {
             sdu_cargo_type,
             resource_cargo_type,
             cargo_stats_definition,
-            data_running_xp_accounts,
-            council_rank_xp_accounts,
+            data_running_user_points_account,
+            data_running_points_category,
+            data_running_points_modifier_account,
+            council_rank_user_points_account,
+            council_rank_points_category,
+            council_rank_points_modifier_account,
             progression_config,
             points_program,
             cargo_program,

--- a/docs/sage-starbased-patching-plan.md
+++ b/docs/sage-starbased-patching-plan.md
@@ -5,11 +5,11 @@ This document outlines the complete patching strategy for expanding composite ac
 
 ## Progress Summary
 - **Total instruction files**: 106
-- **Completed patches**: 10 (covering 62 files)
-- **Remaining patches**: 6 (covering 44 files)
+- **Completed patches**: 11 (covering 65 files)
+- **Remaining patches**: 5 (covering 41 files)
 - **Estimated total patches**: 16
 
-## Completed Patches (01-10)
+## Completed Patches (01-11)
 
 ### Patch 01: Accounts
 - **Files**: 1 (fleet.rs)
@@ -158,27 +158,25 @@ This document outlines the complete patching strategy for expanding composite ac
 - **Priority**: 🟡 Medium - Ship escrow management operations
 - **Status**: ✅ Complete (323 lines)
 
----
-
-## Remaining Patches (11-16)
-
-### Priority 1: Core Gameplay (High Priority)
-
-#### Patch 11: Scanning & Discovery
-- **Files**: ~3
+### Patch 11: Scanning & Discovery
+- **Files**: 3
   - scan_for_survey_data_units.rs
   - discover_sector.rs
-  - fleet_state_handler.rs
+  - fleet_state_handler.rs (no changes needed)
 - **Composite accounts**:
-  - `GameAndGameStateAndFleetAndOwnerMut`
-  - `PointsModificationAccounts` (XP rewards in scanning)
-- **Complexity**: Medium-High (includes XP account expansions)
+  - `GameAndGameStateAndFleetAndOwnerMut` → key, owning_profile, owning_profile_faction, fleet, game_id, game_state
+  - `PointsModificationAccounts` (2 instances in scan_for_survey_data_units.rs with unique prefixes)
+    - data_running: data_running_user_points_account, data_running_points_category, data_running_points_modifier_account
+    - council_rank: council_rank_user_points_account, council_rank_points_category, council_rank_points_modifier_account
+- **Complexity**: Medium-High (includes multiple XP account expansions with prefixes)
 - **Priority**: 🔴 High - Core gameplay mechanic
-- **Status**: 🔲 Pending
+- **Status**: ✅ Complete (150 lines)
 
 ---
 
-### Priority 2: Frequently Used Operations (Medium Priority)
+## Remaining Patches (12-16)
+
+### Priority 1: Frequently Used Operations (Medium Priority)
 
 #### Patch 12: Rental System
 - **Files**: ~3
@@ -290,10 +288,10 @@ This document outlines the complete patching strategy for expanding composite ac
 1. ~~**Patch 06** - Fleet Operations (core gameplay)~~ ✅ Complete
 2. ~~**Patch 07** - Fleet Cargo (frequently used)~~ ✅ Complete
 3. ~~**Patch 08** - Starbase Cargo (frequently used)~~ ✅ Complete
-4. **Patch 11** - Scanning & Discovery (core gameplay with XP) - **NEXT**
-5. **Patch 09** - Crew Management
-6. **Patch 10** - Ship Escrow
-7. **Patch 12** - Rental System
+4. ~~**Patch 09** - Crew Management~~ ✅ Complete
+5. ~~**Patch 10** - Ship Escrow~~ ✅ Complete
+6. ~~**Patch 11** - Scanning & Discovery (core gameplay with XP)~~ ✅ Complete
+7. **Patch 12** - Rental System - **NEXT**
 8. **Patch 13** - Game Config (admin)
 9. **Patch 14** - Starbase Config (admin)
 10. **Patch 15** - Resources Config (admin)

--- a/patches/sage-starbased-11-instructions-scanning-discovery.patch
+++ b/patches/sage-starbased-11-instructions-scanning-discovery.patch
@@ -1,0 +1,150 @@
+diff --git a/src/instructions/discover_sector.rs b/src/instructions/discover_sector.rs
+index c220c42..f398901 100644
+--- a/src/instructions/discover_sector.rs
++++ b/src/instructions/discover_sector.rs
+@@ -12,7 +12,13 @@ pub struct DiscoverSector {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct DiscoverSectorInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwner expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub funder: solana_pubkey::Pubkey,
+     pub sector: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+@@ -25,13 +31,26 @@ impl carbon_core::deserialize::ArrangeAccounts for DiscoverSector {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwner expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let funder = next_account(&mut iter)?;
+         let sector = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(DiscoverSectorInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             funder,
+             sector,
+             system_program,
+diff --git a/src/instructions/scan_for_survey_data_units.rs b/src/instructions/scan_for_survey_data_units.rs
+index 07d95af..8585e0c 100644
+--- a/src/instructions/scan_for_survey_data_units.rs
++++ b/src/instructions/scan_for_survey_data_units.rs
+@@ -12,7 +12,13 @@ pub struct ScanForSurveyDataUnits {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct ScanForSurveyDataUnitsInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub survey_data_unit_tracker: solana_pubkey::Pubkey,
+     pub survey_data_unit_tracker_signer: solana_pubkey::Pubkey,
+     pub cargo_hold: solana_pubkey::Pubkey,
+@@ -24,8 +30,14 @@ pub struct ScanForSurveyDataUnitsInstructionAccounts {
+     pub sdu_cargo_type: solana_pubkey::Pubkey,
+     pub resource_cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub data_running_xp_accounts: solana_pubkey::Pubkey,
+-    pub council_rank_xp_accounts: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (data_running)
++    pub data_running_user_points_account: solana_pubkey::Pubkey,
++    pub data_running_points_category: solana_pubkey::Pubkey,
++    pub data_running_points_modifier_account: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (council_rank)
++    pub council_rank_user_points_account: solana_pubkey::Pubkey,
++    pub council_rank_points_category: solana_pubkey::Pubkey,
++    pub council_rank_points_modifier_account: solana_pubkey::Pubkey,
+     pub progression_config: solana_pubkey::Pubkey,
+     pub points_program: solana_pubkey::Pubkey,
+     pub cargo_program: solana_pubkey::Pubkey,
+@@ -41,7 +53,15 @@ impl carbon_core::deserialize::ArrangeAccounts for ScanForSurveyDataUnits {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let survey_data_unit_tracker = next_account(&mut iter)?;
+         let survey_data_unit_tracker_signer = next_account(&mut iter)?;
+         let cargo_hold = next_account(&mut iter)?;
+@@ -53,8 +73,17 @@ impl carbon_core::deserialize::ArrangeAccounts for ScanForSurveyDataUnits {
+         let sdu_cargo_type = next_account(&mut iter)?;
+         let resource_cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let data_running_xp_accounts = next_account(&mut iter)?;
+-        let council_rank_xp_accounts = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (data_running)
++        let data_running_user_points_account = next_account(&mut iter)?;
++        let data_running_points_category = next_account(&mut iter)?;
++        let data_running_points_modifier_account = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (council_rank)
++        let council_rank_user_points_account = next_account(&mut iter)?;
++        let council_rank_points_category = next_account(&mut iter)?;
++        let council_rank_points_modifier_account = next_account(&mut iter)?;
++
+         let progression_config = next_account(&mut iter)?;
+         let points_program = next_account(&mut iter)?;
+         let cargo_program = next_account(&mut iter)?;
+@@ -63,7 +92,12 @@ impl carbon_core::deserialize::ArrangeAccounts for ScanForSurveyDataUnits {
+         let recent_slothashes = next_account(&mut iter)?;
+ 
+         Some(ScanForSurveyDataUnitsInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             survey_data_unit_tracker,
+             survey_data_unit_tracker_signer,
+             cargo_hold,
+@@ -75,8 +109,12 @@ impl carbon_core::deserialize::ArrangeAccounts for ScanForSurveyDataUnits {
+             sdu_cargo_type,
+             resource_cargo_type,
+             cargo_stats_definition,
+-            data_running_xp_accounts,
+-            council_rank_xp_accounts,
++            data_running_user_points_account,
++            data_running_points_category,
++            data_running_points_modifier_account,
++            council_rank_user_points_account,
++            council_rank_points_category,
++            council_rank_points_modifier_account,
+             progression_config,
+             points_program,
+             cargo_program,


### PR DESCRIPTION
# Expand composite accounts in scanning and discovery instructions

### TL;DR

Expanded composite account structures in the scanning and discovery instructions to improve decoder clarity and maintainability.

### What changed?

- In `discover_sector.rs`:
  - Expanded `game_accounts_fleet_and_owner` into its component fields: `key`, `owning_profile`, `owning_profile_faction`, `fleet`, `game_id`, and `game_state`
  
- In `scan_for_survey_data_units.rs`:
  - Expanded `game_accounts_fleet_and_owner` into its component fields
  - Expanded two instances of `PointsModificationAccounts` with prefixes:
    - `data_running_xp_accounts` → `data_running_user_points_account`, `data_running_points_category`, `data_running_points_modifier_account`
    - `council_rank_xp_accounts` → `council_rank_user_points_account`, `council_rank_points_category`, `council_rank_points_modifier_account`

- Updated the patching plan documentation to mark Patch 11 as complete

### How to test?

1. Verify that the expanded account structures match the expected account layout in the Sage program
2. Test decoding actual transactions that use the `discover_sector` and `scan_for_survey_data_units` instructions
3. Confirm that all account fields are properly populated when decoding transactions

### Why make this change?

This change is part of the ongoing effort to expand composite account structures in the Sage decoders. By explicitly listing all component accounts, we improve:

1. Transparency - making it clear which accounts are involved in each instruction
2. Debuggability - allowing easier inspection of individual account values
3. Maintainability - reducing the cognitive load when working with these decoders

This completes Patch 11 in the patching plan, focusing on core gameplay mechanics related to scanning and discovery.