### PR TITLE
feat: sage-holosim patch 04 instructions mining

### DIFF
--- a/carbon-decoders/sage-holosim-decoder/src/instructions/start_mining_asteroid.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/start_mining_asteroid.rs
@@ -12,9 +12,17 @@ pub struct StartMiningAsteroid {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StartMiningAsteroidInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub fleet_fuel_token_account: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub mine_item: solana_pubkey::Pubkey,
     pub resource: solana_pubkey::Pubkey,
     pub planet: solana_pubkey::Pubkey,
@@ -27,17 +35,35 @@ impl carbon_core::deserialize::ArrangeAccounts for StartMiningAsteroid {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let fleet_fuel_token_account = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let mine_item = next_account(&mut iter)?;
         let resource = next_account(&mut iter)?;
         let planet = next_account(&mut iter)?;
 
         Some(StartMiningAsteroidInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             fleet_fuel_token_account,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             mine_item,
             resource,
             planet,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/stop_mining_asteroid.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/stop_mining_asteroid.rs
@@ -12,7 +12,13 @@ pub struct StopMiningAsteroid {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StopMiningAsteroidInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub mine_item: solana_pubkey::Pubkey,
     pub resource: solana_pubkey::Pubkey,
     pub planet: solana_pubkey::Pubkey,
@@ -21,9 +27,18 @@ pub struct StopMiningAsteroidInstructionAccounts {
     pub cargo_stats_definition: solana_pubkey::Pubkey,
     pub token_from: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
-    pub pilot_xp_accounts: solana_pubkey::Pubkey,
-    pub mining_xp_accounts: solana_pubkey::Pubkey,
-    pub council_rank_xp_accounts: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (pilot)
+    pub pilot_user_points_account: solana_pubkey::Pubkey,
+    pub pilot_points_category: solana_pubkey::Pubkey,
+    pub pilot_points_modifier_account: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (mining)
+    pub mining_user_points_account: solana_pubkey::Pubkey,
+    pub mining_points_category: solana_pubkey::Pubkey,
+    pub mining_points_modifier_account: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (council_rank)
+    pub council_rank_user_points_account: solana_pubkey::Pubkey,
+    pub council_rank_points_category: solana_pubkey::Pubkey,
+    pub council_rank_points_modifier_account: solana_pubkey::Pubkey,
     pub progression_config: solana_pubkey::Pubkey,
     pub points_program: solana_pubkey::Pubkey,
     pub cargo_program: solana_pubkey::Pubkey,
@@ -37,7 +52,15 @@ impl carbon_core::deserialize::ArrangeAccounts for StopMiningAsteroid {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let mine_item = next_account(&mut iter)?;
         let resource = next_account(&mut iter)?;
         let planet = next_account(&mut iter)?;
@@ -46,16 +69,34 @@ impl carbon_core::deserialize::ArrangeAccounts for StopMiningAsteroid {
         let cargo_stats_definition = next_account(&mut iter)?;
         let token_from = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
-        let pilot_xp_accounts = next_account(&mut iter)?;
-        let mining_xp_accounts = next_account(&mut iter)?;
-        let council_rank_xp_accounts = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (pilot)
+        let pilot_user_points_account = next_account(&mut iter)?;
+        let pilot_points_category = next_account(&mut iter)?;
+        let pilot_points_modifier_account = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (mining)
+        let mining_user_points_account = next_account(&mut iter)?;
+        let mining_points_category = next_account(&mut iter)?;
+        let mining_points_modifier_account = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (council_rank)
+        let council_rank_user_points_account = next_account(&mut iter)?;
+        let council_rank_points_category = next_account(&mut iter)?;
+        let council_rank_points_modifier_account = next_account(&mut iter)?;
+
         let progression_config = next_account(&mut iter)?;
         let points_program = next_account(&mut iter)?;
         let cargo_program = next_account(&mut iter)?;
         let token_program = next_account(&mut iter)?;
 
         Some(StopMiningAsteroidInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             mine_item,
             resource,
             planet,
@@ -64,9 +105,15 @@ impl carbon_core::deserialize::ArrangeAccounts for StopMiningAsteroid {
             cargo_stats_definition,
             token_from,
             token_mint,
-            pilot_xp_accounts,
-            mining_xp_accounts,
-            council_rank_xp_accounts,
+            pilot_user_points_account,
+            pilot_points_category,
+            pilot_points_modifier_account,
+            mining_user_points_account,
+            mining_points_category,
+            mining_points_modifier_account,
+            council_rank_user_points_account,
+            council_rank_points_category,
+            council_rank_points_modifier_account,
             progression_config,
             points_program,
             cargo_program,

--- a/docs/sage-holosim-patching-plan.md
+++ b/docs/sage-holosim-patching-plan.md
@@ -5,12 +5,12 @@ This document outlines the complete patching strategy for expanding composite ac
 
 ## Progress Summary
 - **Total instruction files**: 124
-- **Completed patches**: 3 (covering 3 instruction files + 2 account files)
-- **Files needing composite expansions**: ~92 remaining
-- **Remaining patches**: ~14
+- **Completed patches**: 4 (covering 5 instruction files + 2 account files)
+- **Files needing composite expansions**: ~90 remaining
+- **Remaining patches**: ~13
 - **Estimated total patches**: ~17
 
-## Completed Patches (01-03)
+## Completed Patches (01-04)
 
 ### Patch 01: Disable Combat Log Events
 - **Files**: 2 (combat_log_event.rs, combat_resolved_event.rs) + mod.rs updates
@@ -37,22 +37,23 @@ This document outlines the complete patching strategy for expanding composite ac
 - **Priority**: 🔴 High - Core exploration mechanic
 - **Status**: ✅ Complete (150 lines)
 
----
-
-## Remaining Patches (04-17)
-
-### Priority 1: Core Gameplay - Mining, Movement (High Priority)
-
-#### Patch 04: Mining Operations
+### Patch 04: Mining Operations
 - **Files**: 2
   - start_mining_asteroid.rs
   - stop_mining_asteroid.rs
 - **Composite accounts**:
-  - `game_accounts_fleet_and_owner` → GameAndGameStateAndFleetAndOwnerMut (6 accounts)
+  - `game_accounts_fleet_and_owner` → GameAndGameStateAndFleetAndOwnerMut (6 accounts): key, owning_profile, owning_profile_faction, fleet, game_id, game_state
   - `starbase_and_starbase_player` → StarbaseMutAndStarbasePlayer (2 accounts): starbase, starbase_player
-- **Complexity**: Medium
+  - Multiple PointsModificationAccounts in stop_mining_asteroid.rs (3 instances): pilot_, mining_, council_rank_
+- **Complexity**: Medium (includes multiple XP account expansions with unique prefixes)
 - **Priority**: 🔴 High - Core resource gathering mechanic
-- **Status**: 🔲 Pending
+- **Status**: ✅ Complete (180 lines)
+
+---
+
+## Remaining Patches (05-17)
+
+### Priority 1: Core Gameplay - Movement (High Priority)
 
 #### Patch 05: Movement Instructions
 - **Files**: 5
@@ -360,8 +361,8 @@ This document outlines the complete patching strategy for expanding composite ac
 1. ~~**Patch 01** - Disable Combat Log Events~~ ✅ Complete
 2. ~~**Patch 02** - Accounts~~ ✅ Complete
 3. ~~**Patch 03** - Scanning & Discovery~~ ✅ Complete
-4. **Patch 04** - Mining Operations - **NEXT**
-5. **Patch 05** - Movement Instructions
+4. ~~**Patch 04** - Mining Operations~~ ✅ Complete
+5. **Patch 05** - Movement Instructions - **NEXT**
 6. **Patch 06** - Starbase Operations
 7. **Patch 07** - Crafting Instructions
 8. **Patch 08** - Fleet Management

--- a/patches/sage-holosim-04-instructions-mining.patch
+++ b/patches/sage-holosim-04-instructions-mining.patch
@@ -1,0 +1,180 @@
+diff --git a/src/instructions/start_mining_asteroid.rs b/src/instructions/start_mining_asteroid.rs
+index 79fb6e0..71c3ab0 100644
+--- a/src/instructions/start_mining_asteroid.rs
++++ b/src/instructions/start_mining_asteroid.rs
+@@ -12,9 +12,17 @@ pub struct StartMiningAsteroid {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StartMiningAsteroidInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub fleet_fuel_token_account: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub mine_item: solana_pubkey::Pubkey,
+     pub resource: solana_pubkey::Pubkey,
+     pub planet: solana_pubkey::Pubkey,
+@@ -27,17 +35,35 @@ impl carbon_core::deserialize::ArrangeAccounts for StartMiningAsteroid {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let fleet_fuel_token_account = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let mine_item = next_account(&mut iter)?;
+         let resource = next_account(&mut iter)?;
+         let planet = next_account(&mut iter)?;
+ 
+         Some(StartMiningAsteroidInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             fleet_fuel_token_account,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             mine_item,
+             resource,
+             planet,
+diff --git a/src/instructions/stop_mining_asteroid.rs b/src/instructions/stop_mining_asteroid.rs
+index bf9250f..898cc42 100644
+--- a/src/instructions/stop_mining_asteroid.rs
++++ b/src/instructions/stop_mining_asteroid.rs
+@@ -12,7 +12,13 @@ pub struct StopMiningAsteroid {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StopMiningAsteroidInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub mine_item: solana_pubkey::Pubkey,
+     pub resource: solana_pubkey::Pubkey,
+     pub planet: solana_pubkey::Pubkey,
+@@ -21,9 +27,18 @@ pub struct StopMiningAsteroidInstructionAccounts {
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+-    pub pilot_xp_accounts: solana_pubkey::Pubkey,
+-    pub mining_xp_accounts: solana_pubkey::Pubkey,
+-    pub council_rank_xp_accounts: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (pilot)
++    pub pilot_user_points_account: solana_pubkey::Pubkey,
++    pub pilot_points_category: solana_pubkey::Pubkey,
++    pub pilot_points_modifier_account: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (mining)
++    pub mining_user_points_account: solana_pubkey::Pubkey,
++    pub mining_points_category: solana_pubkey::Pubkey,
++    pub mining_points_modifier_account: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (council_rank)
++    pub council_rank_user_points_account: solana_pubkey::Pubkey,
++    pub council_rank_points_category: solana_pubkey::Pubkey,
++    pub council_rank_points_modifier_account: solana_pubkey::Pubkey,
+     pub progression_config: solana_pubkey::Pubkey,
+     pub points_program: solana_pubkey::Pubkey,
+     pub cargo_program: solana_pubkey::Pubkey,
+@@ -37,7 +52,15 @@ impl carbon_core::deserialize::ArrangeAccounts for StopMiningAsteroid {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let mine_item = next_account(&mut iter)?;
+         let resource = next_account(&mut iter)?;
+         let planet = next_account(&mut iter)?;
+@@ -46,16 +69,34 @@ impl carbon_core::deserialize::ArrangeAccounts for StopMiningAsteroid {
+         let cargo_stats_definition = next_account(&mut iter)?;
+         let token_from = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+-        let pilot_xp_accounts = next_account(&mut iter)?;
+-        let mining_xp_accounts = next_account(&mut iter)?;
+-        let council_rank_xp_accounts = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (pilot)
++        let pilot_user_points_account = next_account(&mut iter)?;
++        let pilot_points_category = next_account(&mut iter)?;
++        let pilot_points_modifier_account = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (mining)
++        let mining_user_points_account = next_account(&mut iter)?;
++        let mining_points_category = next_account(&mut iter)?;
++        let mining_points_modifier_account = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (council_rank)
++        let council_rank_user_points_account = next_account(&mut iter)?;
++        let council_rank_points_category = next_account(&mut iter)?;
++        let council_rank_points_modifier_account = next_account(&mut iter)?;
++
+         let progression_config = next_account(&mut iter)?;
+         let points_program = next_account(&mut iter)?;
+         let cargo_program = next_account(&mut iter)?;
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(StopMiningAsteroidInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             mine_item,
+             resource,
+             planet,
+@@ -64,9 +105,15 @@ impl carbon_core::deserialize::ArrangeAccounts for StopMiningAsteroid {
+             cargo_stats_definition,
+             token_from,
+             token_mint,
+-            pilot_xp_accounts,
+-            mining_xp_accounts,
+-            council_rank_xp_accounts,
++            pilot_user_points_account,
++            pilot_points_category,
++            pilot_points_modifier_account,
++            mining_user_points_account,
++            mining_points_category,
++            mining_points_modifier_account,
++            council_rank_user_points_account,
++            council_rank_points_category,
++            council_rank_points_modifier_account,
+             progression_config,
+             points_program,
+             cargo_program,


### PR DESCRIPTION
### TL;DR

Expanded composite account structures in mining asteroid operations to improve data visibility and debugging.

### What changed?

- In `start_mining_asteroid.rs`:
  - Expanded `game_accounts_fleet_and_owner` into 6 individual accounts: `key`, `owning_profile`, `owning_profile_faction`, `fleet`, `game_id`, and `game_state`
  - Expanded `starbase_and_starbase_player` into `starbase` and `starbase_player`

- In `stop_mining_asteroid.rs`:
  - Expanded `game_accounts_fleet_and_owner` into 6 individual accounts
  - Expanded three XP account composites (`pilot_xp_accounts`, `mining_xp_accounts`, `council_rank_xp_accounts`) into their respective components with appropriate prefixes

- Updated the patching plan documentation to mark Patch 04 as complete and update progress metrics

### How to test?

1. Run the decoder against transactions that involve mining operations
2. Verify that the expanded account fields are correctly populated
3. Confirm that the decoder can properly parse both start and stop mining asteroid instructions

### Why make this change?

This change improves the decoder's ability to provide detailed information about mining operations by exposing individual account fields that were previously hidden in composite structures. This enhances debugging capabilities and provides better visibility into the game's mining mechanics, which is a core resource gathering feature.