### PR TITLE
feat: sage-holosim patch 05 instructions movement

### DIFF
--- a/carbon-decoders/sage-holosim-decoder/src/instructions/mine_asteroid_to_respawn.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/mine_asteroid_to_respawn.rs
@@ -12,7 +12,13 @@ pub struct MineAsteroidToRespawn {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct MineAsteroidToRespawnInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub resource: solana_pubkey::Pubkey,
     pub planet: solana_pubkey::Pubkey,
     pub atlas_token_from: solana_pubkey::Pubkey,
@@ -27,7 +33,15 @@ impl carbon_core::deserialize::ArrangeAccounts for MineAsteroidToRespawn {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let resource = next_account(&mut iter)?;
         let planet = next_account(&mut iter)?;
         let atlas_token_from = next_account(&mut iter)?;
@@ -35,7 +49,12 @@ impl carbon_core::deserialize::ArrangeAccounts for MineAsteroidToRespawn {
         let token_program = next_account(&mut iter)?;
 
         Some(MineAsteroidToRespawnInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             resource,
             planet,
             atlas_token_from,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/start_subwarp.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/start_subwarp.rs
@@ -12,7 +12,13 @@ pub struct StartSubwarp {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StartSubwarpInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for StartSubwarp {
@@ -22,10 +28,22 @@ impl carbon_core::deserialize::ArrangeAccounts for StartSubwarp {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
 
         Some(StartSubwarpInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
         })
     }
 }

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/stop_subwarp.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/stop_subwarp.rs
@@ -12,7 +12,13 @@ pub struct StopSubwarp {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StopSubwarpInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
 }
 
 impl carbon_core::deserialize::ArrangeAccounts for StopSubwarp {
@@ -22,10 +28,22 @@ impl carbon_core::deserialize::ArrangeAccounts for StopSubwarp {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
 
         Some(StopSubwarpInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
         })
     }
 }

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/warp_lane.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/warp_lane.rs
@@ -12,7 +12,13 @@ pub struct WarpLane {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct WarpLaneInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub from_starbase: solana_pubkey::Pubkey,
     pub to_starbase: solana_pubkey::Pubkey,
     pub from_sector: solana_pubkey::Pubkey,
@@ -36,7 +42,15 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpLane {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let from_starbase = next_account(&mut iter)?;
         let to_starbase = next_account(&mut iter)?;
         let from_sector = next_account(&mut iter)?;
@@ -53,7 +67,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpLane {
         let token_program = next_account(&mut iter)?;
 
         Some(WarpLaneInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             from_starbase,
             to_starbase,
             from_sector,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/warp_to_coordinate.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/warp_to_coordinate.rs
@@ -12,7 +12,13 @@ pub struct WarpToCoordinate {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct WarpToCoordinateInstructionAccounts {
-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
+    // GameAndGameStateAndFleetAndOwnerMut expansion
+    pub key: solana_pubkey::Pubkey,
+    pub owning_profile: solana_pubkey::Pubkey,
+    pub owning_profile_faction: solana_pubkey::Pubkey,
+    pub fleet: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub fuel_tank: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub stats_definition: solana_pubkey::Pubkey,
@@ -29,7 +35,15 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpToCoordinate {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
+
+        // GameAndGameStateAndFleetAndOwnerMut expansion
+        let key = next_account(&mut iter)?;
+        let owning_profile = next_account(&mut iter)?;
+        let owning_profile_faction = next_account(&mut iter)?;
+        let fleet = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let fuel_tank = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let stats_definition = next_account(&mut iter)?;
@@ -39,7 +53,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpToCoordinate {
         let token_program = next_account(&mut iter)?;
 
         Some(WarpToCoordinateInstructionAccounts {
-            game_accounts_fleet_and_owner,
+            key,
+            owning_profile,
+            owning_profile_faction,
+            fleet,
+            game_id,
+            game_state,
             fuel_tank,
             cargo_type,
             stats_definition,

--- a/docs/sage-holosim-patching-plan.md
+++ b/docs/sage-holosim-patching-plan.md
@@ -5,12 +5,12 @@ This document outlines the complete patching strategy for expanding composite ac
 
 ## Progress Summary
 - **Total instruction files**: 124
-- **Completed patches**: 4 (covering 5 instruction files + 2 account files)
-- **Files needing composite expansions**: ~90 remaining
-- **Remaining patches**: ~13
+- **Completed patches**: 5 (covering 10 instruction files + 2 account files)
+- **Files needing composite expansions**: ~85 remaining
+- **Remaining patches**: ~12
 - **Estimated total patches**: ~17
 
-## Completed Patches (01-04)
+## Completed Patches (01-05)
 
 ### Patch 01: Disable Combat Log Events
 - **Files**: 2 (combat_log_event.rs, combat_resolved_event.rs) + mod.rs updates
@@ -49,13 +49,7 @@ This document outlines the complete patching strategy for expanding composite ac
 - **Priority**: 🔴 High - Core resource gathering mechanic
 - **Status**: ✅ Complete (180 lines)
 
----
-
-## Remaining Patches (05-17)
-
-### Priority 1: Core Gameplay - Movement (High Priority)
-
-#### Patch 05: Movement Instructions
+### Patch 05: Movement Instructions
 - **Files**: 5
   - start_subwarp.rs
   - stop_subwarp.rs
@@ -63,12 +57,14 @@ This document outlines the complete patching strategy for expanding composite ac
   - warp_to_coordinate.rs
   - mine_asteroid_to_respawn.rs
 - **Composite accounts**:
-  - `game_accounts_fleet_and_owner` → GameAndGameStateAndFleetAndOwnerMut (6 accounts)
-- **Complexity**: Medium
+  - `game_accounts_fleet_and_owner` → GameAndGameStateAndFleetAndOwnerMut (6 accounts): key, owning_profile, owning_profile_faction, fleet, game_id, game_state
+- **Complexity**: Low-Medium (single composite pattern across all 5 files)
 - **Priority**: 🔴 High - Core movement mechanics
-- **Status**: 🔲 Pending
+- **Status**: ✅ Complete (238 lines)
 
 ---
+
+## Remaining Patches (06-17)
 
 ### Priority 2: Frequently Used Operations (Medium-High Priority)
 
@@ -362,8 +358,8 @@ This document outlines the complete patching strategy for expanding composite ac
 2. ~~**Patch 02** - Accounts~~ ✅ Complete
 3. ~~**Patch 03** - Scanning & Discovery~~ ✅ Complete
 4. ~~**Patch 04** - Mining Operations~~ ✅ Complete
-5. **Patch 05** - Movement Instructions - **NEXT**
-6. **Patch 06** - Starbase Operations
+5. ~~**Patch 05** - Movement Instructions~~ ✅ Complete
+6. **Patch 06** - Starbase Operations - **NEXT**
 7. **Patch 07** - Crafting Instructions
 8. **Patch 08** - Fleet Management
 9. **Patch 09** - Fleet Cargo Operations

--- a/patches/sage-holosim-05-instructions-movement.patch
+++ b/patches/sage-holosim-05-instructions-movement.patch
@@ -1,0 +1,238 @@
+diff --git a/src/instructions/mine_asteroid_to_respawn.rs b/src/instructions/mine_asteroid_to_respawn.rs
+index d6779d2..98dd15e 100644
+--- a/src/instructions/mine_asteroid_to_respawn.rs
++++ b/src/instructions/mine_asteroid_to_respawn.rs
+@@ -12,7 +12,13 @@ pub struct MineAsteroidToRespawn {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct MineAsteroidToRespawnInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub resource: solana_pubkey::Pubkey,
+     pub planet: solana_pubkey::Pubkey,
+     pub atlas_token_from: solana_pubkey::Pubkey,
+@@ -27,7 +33,15 @@ impl carbon_core::deserialize::ArrangeAccounts for MineAsteroidToRespawn {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let resource = next_account(&mut iter)?;
+         let planet = next_account(&mut iter)?;
+         let atlas_token_from = next_account(&mut iter)?;
+@@ -35,7 +49,12 @@ impl carbon_core::deserialize::ArrangeAccounts for MineAsteroidToRespawn {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(MineAsteroidToRespawnInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             resource,
+             planet,
+             atlas_token_from,
+diff --git a/src/instructions/start_subwarp.rs b/src/instructions/start_subwarp.rs
+index 5db456b..4913304 100644
+--- a/src/instructions/start_subwarp.rs
++++ b/src/instructions/start_subwarp.rs
+@@ -12,7 +12,13 @@ pub struct StartSubwarp {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StartSubwarpInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+ }
+ 
+ impl carbon_core::deserialize::ArrangeAccounts for StartSubwarp {
+@@ -22,10 +28,22 @@ impl carbon_core::deserialize::ArrangeAccounts for StartSubwarp {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
+ 
+         Some(StartSubwarpInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+         })
+     }
+ }
+diff --git a/src/instructions/stop_subwarp.rs b/src/instructions/stop_subwarp.rs
+index bbbe842..fc101ac 100644
+--- a/src/instructions/stop_subwarp.rs
++++ b/src/instructions/stop_subwarp.rs
+@@ -12,7 +12,13 @@ pub struct StopSubwarp {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StopSubwarpInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+ }
+ 
+ impl carbon_core::deserialize::ArrangeAccounts for StopSubwarp {
+@@ -22,10 +28,22 @@ impl carbon_core::deserialize::ArrangeAccounts for StopSubwarp {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
+ 
+         Some(StopSubwarpInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+         })
+     }
+ }
+diff --git a/src/instructions/warp_lane.rs b/src/instructions/warp_lane.rs
+index 278efd7..8fa568d 100644
+--- a/src/instructions/warp_lane.rs
++++ b/src/instructions/warp_lane.rs
+@@ -12,7 +12,13 @@ pub struct WarpLane {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct WarpLaneInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub from_starbase: solana_pubkey::Pubkey,
+     pub to_starbase: solana_pubkey::Pubkey,
+     pub from_sector: solana_pubkey::Pubkey,
+@@ -36,7 +42,15 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpLane {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let from_starbase = next_account(&mut iter)?;
+         let to_starbase = next_account(&mut iter)?;
+         let from_sector = next_account(&mut iter)?;
+@@ -53,7 +67,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpLane {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(WarpLaneInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             from_starbase,
+             to_starbase,
+             from_sector,
+diff --git a/src/instructions/warp_to_coordinate.rs b/src/instructions/warp_to_coordinate.rs
+index 80b4e6c..fd9601e 100644
+--- a/src/instructions/warp_to_coordinate.rs
++++ b/src/instructions/warp_to_coordinate.rs
+@@ -12,7 +12,13 @@ pub struct WarpToCoordinate {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct WarpToCoordinateInstructionAccounts {
+-    pub game_accounts_fleet_and_owner: solana_pubkey::Pubkey,
++    // GameAndGameStateAndFleetAndOwnerMut expansion
++    pub key: solana_pubkey::Pubkey,
++    pub owning_profile: solana_pubkey::Pubkey,
++    pub owning_profile_faction: solana_pubkey::Pubkey,
++    pub fleet: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub fuel_tank: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub stats_definition: solana_pubkey::Pubkey,
+@@ -29,7 +35,15 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpToCoordinate {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let game_accounts_fleet_and_owner = next_account(&mut iter)?;
++
++        // GameAndGameStateAndFleetAndOwnerMut expansion
++        let key = next_account(&mut iter)?;
++        let owning_profile = next_account(&mut iter)?;
++        let owning_profile_faction = next_account(&mut iter)?;
++        let fleet = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let fuel_tank = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let stats_definition = next_account(&mut iter)?;
+@@ -39,7 +53,12 @@ impl carbon_core::deserialize::ArrangeAccounts for WarpToCoordinate {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(WarpToCoordinateInstructionAccounts {
+-            game_accounts_fleet_and_owner,
++            key,
++            owning_profile,
++            owning_profile_faction,
++            fleet,
++            game_id,
++            game_state,
+             fuel_tank,
+             cargo_type,
+             stats_definition,


### PR DESCRIPTION
### TL;DR

Expanded the `game_accounts_fleet_and_owner` composite account in movement-related instructions to expose individual account fields.

### What changed?

This PR expands the `game_accounts_fleet_and_owner` composite account into its individual components across five movement-related instruction files:
- `mine_asteroid_to_respawn.rs`
- `start_subwarp.rs`
- `stop_subwarp.rs`
- `warp_lane.rs`
- `warp_to_coordinate.rs`

The composite account is replaced with six individual fields:
- `key`
- `owning_profile`
- `owning_profile_faction`
- `fleet`
- `game_id`
- `game_state`

The patching plan document is also updated to reflect this completed work.

### How to test?

1. Verify that the decoder can properly parse transactions containing these movement instructions
2. Confirm that the expanded account fields are correctly populated in the decoded output
3. Check that the account arrangement logic correctly maps the input accounts to the expanded fields

### Why make this change?

This change improves the decoder's ability to provide detailed information about movement-related transactions by exposing the individual accounts that were previously hidden within the composite account. This allows for better analysis and debugging of fleet movement operations in the game.