### PR TITLE
feat: sage-holosim patch 06 instructions starbase

### DIFF
--- a/carbon-decoders/sage-holosim-decoder/src/instructions/close_upgrade_process.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/close_upgrade_process.rs
@@ -13,12 +13,19 @@ pub struct CloseUpgradeProcess {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CloseUpgradeProcessInstructionAccounts {
     pub funds_to: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub resource_crafting_instance: solana_pubkey::Pubkey,
     pub resource_crafting_process: solana_pubkey::Pubkey,
     pub resource_recipe: solana_pubkey::Pubkey,
     pub resource_crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
 }
 
@@ -30,22 +37,38 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseUpgradeProcess {
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funds_to = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let resource_crafting_instance = next_account(&mut iter)?;
         let resource_crafting_process = next_account(&mut iter)?;
         let resource_recipe = next_account(&mut iter)?;
         let resource_crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let crafting_program = next_account(&mut iter)?;
 
         Some(CloseUpgradeProcessInstructionAccounts {
             funds_to,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             resource_crafting_instance,
             resource_crafting_process,
             resource_recipe,
             resource_crafting_facility,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
         })
     }

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/complete_starbase_upgrade.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/complete_starbase_upgrade.rs
@@ -13,13 +13,20 @@ pub struct CompleteStarbaseUpgrade {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CompleteStarbaseUpgradeInstructionAccounts {
     pub funder: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub upgrade_facility: solana_pubkey::Pubkey,
     pub upgrade_recipe: solana_pubkey::Pubkey,
     pub new_recipe_category: solana_pubkey::Pubkey,
     pub crafting_domain: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
@@ -32,25 +39,41 @@ impl carbon_core::deserialize::ArrangeAccounts for CompleteStarbaseUpgrade {
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funder = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_facility = next_account(&mut iter)?;
         let upgrade_facility = next_account(&mut iter)?;
         let upgrade_recipe = next_account(&mut iter)?;
         let new_recipe_category = next_account(&mut iter)?;
         let crafting_domain = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let crafting_program = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
         Some(CompleteStarbaseUpgradeInstructionAccounts {
             funder,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_facility,
             upgrade_facility,
             upgrade_recipe,
             new_recipe_category,
             crafting_domain,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
             system_program,
         })

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/create_cargo_pod.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/create_cargo_pod.rs
@@ -13,10 +13,17 @@ pub struct CreateCargoPod {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateCargoPodInstructionAccounts {
     pub funder: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub cargo_pod: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub cargo_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
@@ -29,19 +36,35 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateCargoPod {
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funder = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let cargo_pod = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let cargo_program = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
         Some(CreateCargoPodInstructionAccounts {
             funder,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             cargo_pod,
             cargo_stats_definition,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             cargo_program,
             system_program,
         })

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/create_starbase_upgrade_resource_process.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/create_starbase_upgrade_resource_process.rs
@@ -13,13 +13,20 @@ pub struct CreateStarbaseUpgradeResourceProcess {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateStarbaseUpgradeResourceProcessInstructionAccounts {
     pub funder: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub upgrade_facility: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_domain: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
@@ -32,25 +39,41 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateStarbaseUpgradeResource
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funder = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let upgrade_facility = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_domain = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let crafting_program = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
         Some(CreateStarbaseUpgradeResourceProcessInstructionAccounts {
             funder,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             upgrade_facility,
             crafting_process,
             crafting_recipe,
             crafting_domain,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
             system_program,
         })

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/deposit_starbase_upkeep_resource.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/deposit_starbase_upkeep_resource.rs
@@ -13,15 +13,25 @@ pub struct DepositStarbaseUpkeepResource {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DepositStarbaseUpkeepResourceInstructionAccounts {
     pub funds_to: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub cargo_pod_from: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
     pub token_from: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub resource_recipe: solana_pubkey::Pubkey,
-    pub loyalty_points_accounts: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (loyalty)
+    pub loyalty_user_points_account: solana_pubkey::Pubkey,
+    pub loyalty_points_category: solana_pubkey::Pubkey,
+    pub loyalty_points_modifier_account: solana_pubkey::Pubkey,
     pub progression_config: solana_pubkey::Pubkey,
     pub points_program: solana_pubkey::Pubkey,
     pub cargo_program: solana_pubkey::Pubkey,
@@ -36,15 +46,31 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositStarbaseUpkeepResource
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funds_to = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let cargo_pod_from = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
         let token_from = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let resource_recipe = next_account(&mut iter)?;
-        let loyalty_points_accounts = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (loyalty)
+        let loyalty_user_points_account = next_account(&mut iter)?;
+        let loyalty_points_category = next_account(&mut iter)?;
+        let loyalty_points_modifier_account = next_account(&mut iter)?;
+
         let progression_config = next_account(&mut iter)?;
         let points_program = next_account(&mut iter)?;
         let cargo_program = next_account(&mut iter)?;
@@ -52,15 +78,22 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositStarbaseUpkeepResource
 
         Some(DepositStarbaseUpkeepResourceInstructionAccounts {
             funds_to,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             cargo_pod_from,
             cargo_type,
             cargo_stats_definition,
             token_from,
             token_mint,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             resource_recipe,
-            loyalty_points_accounts,
+            loyalty_user_points_account,
+            loyalty_points_category,
+            loyalty_points_modifier_account,
             progression_config,
             points_program,
             cargo_program,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/start_starbase_upgrade.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/start_starbase_upgrade.rs
@@ -13,10 +13,17 @@ pub struct StartStarbaseUpgrade {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StartStarbaseUpgradeInstructionAccounts {
     pub funder: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub upgrade_facility: solana_pubkey::Pubkey,
     pub upgrade_recipe: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
 
@@ -28,18 +35,34 @@ impl carbon_core::deserialize::ArrangeAccounts for StartStarbaseUpgrade {
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funder = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let upgrade_facility = next_account(&mut iter)?;
         let upgrade_recipe = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let system_program = next_account(&mut iter)?;
 
         Some(StartStarbaseUpgradeInstructionAccounts {
             funder,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             upgrade_facility,
             upgrade_recipe,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             system_program,
         })
     }

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/submit_starbase_upgrade_resource.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/submit_starbase_upgrade_resource.rs
@@ -13,7 +13,9 @@ pub struct SubmitStarbaseUpgradeResource {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SubmitStarbaseUpgradeResourceInstructionAccounts {
     pub funds_to: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseMutAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub resource_crafting_instance: solana_pubkey::Pubkey,
     pub resource_crafting_process: solana_pubkey::Pubkey,
     pub resource_crafting_facility: solana_pubkey::Pubkey,
@@ -26,8 +28,16 @@ pub struct SubmitStarbaseUpgradeResourceInstructionAccounts {
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
-    pub loyalty_points_accounts: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (loyalty)
+    pub loyalty_user_points_account: solana_pubkey::Pubkey,
+    pub loyalty_points_category: solana_pubkey::Pubkey,
+    pub loyalty_points_modifier_account: solana_pubkey::Pubkey,
     pub progression_config: solana_pubkey::Pubkey,
     pub points_program: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -43,7 +53,11 @@ impl carbon_core::deserialize::ArrangeAccounts for SubmitStarbaseUpgradeResource
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funds_to = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseMutAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let resource_crafting_instance = next_account(&mut iter)?;
         let resource_crafting_process = next_account(&mut iter)?;
         let resource_crafting_facility = next_account(&mut iter)?;
@@ -56,8 +70,19 @@ impl carbon_core::deserialize::ArrangeAccounts for SubmitStarbaseUpgradeResource
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
-        let loyalty_points_accounts = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (loyalty)
+        let loyalty_user_points_account = next_account(&mut iter)?;
+        let loyalty_points_category = next_account(&mut iter)?;
+        let loyalty_points_modifier_account = next_account(&mut iter)?;
+
         let progression_config = next_account(&mut iter)?;
         let points_program = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
@@ -66,7 +91,8 @@ impl carbon_core::deserialize::ArrangeAccounts for SubmitStarbaseUpgradeResource
 
         Some(SubmitStarbaseUpgradeResourceInstructionAccounts {
             funds_to,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             resource_crafting_instance,
             resource_crafting_process,
             resource_crafting_facility,
@@ -79,8 +105,14 @@ impl carbon_core::deserialize::ArrangeAccounts for SubmitStarbaseUpgradeResource
             token_from,
             token_to,
             token_mint,
-            game_accounts_and_profile,
-            loyalty_points_accounts,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
+            loyalty_user_points_account,
+            loyalty_points_category,
+            loyalty_points_modifier_account,
             progression_config,
             points_program,
             crafting_program,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/sync_starbase_upgrade_ingredients.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/sync_starbase_upgrade_ingredients.rs
@@ -15,7 +15,12 @@ pub struct SyncStarbaseUpgradeIngredientsInstructionAccounts {
     pub funder: solana_pubkey::Pubkey,
     pub starbase: solana_pubkey::Pubkey,
     pub upgrade_recipe: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
 
@@ -29,14 +34,25 @@ impl carbon_core::deserialize::ArrangeAccounts for SyncStarbaseUpgradeIngredient
         let funder = next_account(&mut iter)?;
         let starbase = next_account(&mut iter)?;
         let upgrade_recipe = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let system_program = next_account(&mut iter)?;
 
         Some(SyncStarbaseUpgradeIngredientsInstructionAccounts {
             funder,
             starbase,
             upgrade_recipe,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             system_program,
         })
     }

--- a/docs/sage-holosim-patching-plan.md
+++ b/docs/sage-holosim-patching-plan.md
@@ -5,12 +5,12 @@ This document outlines the complete patching strategy for expanding composite ac
 
 ## Progress Summary
 - **Total instruction files**: 124
-- **Completed patches**: 5 (covering 10 instruction files + 2 account files)
-- **Files needing composite expansions**: ~85 remaining
-- **Remaining patches**: ~12
+- **Completed patches**: 6 (covering 18 instruction files + 2 account files)
+- **Files needing composite expansions**: ~77 remaining
+- **Remaining patches**: ~11
 - **Estimated total patches**: ~17
 
-## Completed Patches (01-05)
+## Completed Patches (01-06)
 
 ### Patch 01: Disable Combat Log Events
 - **Files**: 2 (combat_log_event.rs, combat_resolved_event.rs) + mod.rs updates
@@ -62,30 +62,30 @@ This document outlines the complete patching strategy for expanding composite ac
 - **Priority**: 🔴 High - Core movement mechanics
 - **Status**: ✅ Complete (238 lines)
 
----
-
-## Remaining Patches (06-17)
-
-### Priority 2: Frequently Used Operations (Medium-High Priority)
-
-#### Patch 06: Starbase Operations
-- **Files**: ~9
+### Patch 06: Starbase Operations
+- **Files**: 8 (repair_starbase.rs deferred to Patch 10)
   - deposit_starbase_upkeep_resource.rs
+  - submit_starbase_upgrade_resource.rs
   - start_starbase_upgrade.rs
   - complete_starbase_upgrade.rs
-  - submit_starbase_upgrade_resource.rs
   - create_starbase_upgrade_resource_process.rs
   - close_upgrade_process.rs
   - sync_starbase_upgrade_ingredients.rs
-  - repair_starbase.rs
   - create_cargo_pod.rs
 - **Composite accounts**:
-  - `starbase_and_starbase_player` → StarbaseMutAndStarbasePlayer (2 accounts)
+  - `starbase_and_starbase_player` → StarbaseMutAndStarbasePlayer (2 accounts): starbase, starbase_player
   - `game_accounts_and_profile` → GameAndGameStateAndProfile (5 accounts): key, profile, profile_faction, game_id, game_state
-  - `loyalty_points_accounts` → PointsModificationAccounts (3 accounts) - for upkeep only
-- **Complexity**: Medium-High
+  - `loyalty_points_accounts` → PointsModificationAccounts (3 accounts): loyalty_user_points_account, loyalty_points_category, loyalty_points_modifier_account
+- **Complexity**: Medium-High (two files with loyalty points in addition to standard starbase pattern)
 - **Priority**: 🟡 Medium-High - Frequently used starbase management
-- **Status**: 🔲 Pending
+- **Status**: ✅ Complete (578 lines)
+- **Note**: repair_starbase.rs deferred to Patch 10 Combat Operations (uses `game_and_fleet_and_owner` composite)
+
+---
+
+## Remaining Patches (07-17)
+
+### Priority 2: Frequently Used Operations (Medium-High Priority)
 
 #### Patch 07: Crafting Instructions
 - **Files**: ~10
@@ -359,8 +359,8 @@ This document outlines the complete patching strategy for expanding composite ac
 3. ~~**Patch 03** - Scanning & Discovery~~ ✅ Complete
 4. ~~**Patch 04** - Mining Operations~~ ✅ Complete
 5. ~~**Patch 05** - Movement Instructions~~ ✅ Complete
-6. **Patch 06** - Starbase Operations - **NEXT**
-7. **Patch 07** - Crafting Instructions
+6. ~~**Patch 06** - Starbase Operations~~ ✅ Complete
+7. **Patch 07** - Crafting Instructions - **NEXT**
 8. **Patch 08** - Fleet Management
 9. **Patch 09** - Fleet Cargo Operations
 10. **Patch 10** - Combat Operations

--- a/patches/sage-holosim-06-instructions-starbase.patch
+++ b/patches/sage-holosim-06-instructions-starbase.patch
@@ -1,0 +1,578 @@
+diff --git a/src/instructions/close_upgrade_process.rs b/src/instructions/close_upgrade_process.rs
+index 5a0b712..dce7258 100644
+--- a/src/instructions/close_upgrade_process.rs
++++ b/src/instructions/close_upgrade_process.rs
+@@ -13,12 +13,19 @@ pub struct CloseUpgradeProcess {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CloseUpgradeProcessInstructionAccounts {
+     pub funds_to: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub resource_crafting_instance: solana_pubkey::Pubkey,
+     pub resource_crafting_process: solana_pubkey::Pubkey,
+     pub resource_recipe: solana_pubkey::Pubkey,
+     pub resource_crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -30,22 +37,38 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseUpgradeProcess {
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funds_to = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let resource_crafting_instance = next_account(&mut iter)?;
+         let resource_crafting_process = next_account(&mut iter)?;
+         let resource_recipe = next_account(&mut iter)?;
+         let resource_crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(CloseUpgradeProcessInstructionAccounts {
+             funds_to,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             resource_crafting_instance,
+             resource_crafting_process,
+             resource_recipe,
+             resource_crafting_facility,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+         })
+     }
+diff --git a/src/instructions/complete_starbase_upgrade.rs b/src/instructions/complete_starbase_upgrade.rs
+index 956b940..771562a 100644
+--- a/src/instructions/complete_starbase_upgrade.rs
++++ b/src/instructions/complete_starbase_upgrade.rs
+@@ -13,13 +13,20 @@ pub struct CompleteStarbaseUpgrade {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CompleteStarbaseUpgradeInstructionAccounts {
+     pub funder: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub upgrade_facility: solana_pubkey::Pubkey,
+     pub upgrade_recipe: solana_pubkey::Pubkey,
+     pub new_recipe_category: solana_pubkey::Pubkey,
+     pub crafting_domain: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -32,25 +39,41 @@ impl carbon_core::deserialize::ArrangeAccounts for CompleteStarbaseUpgrade {
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funder = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_facility = next_account(&mut iter)?;
+         let upgrade_facility = next_account(&mut iter)?;
+         let upgrade_recipe = next_account(&mut iter)?;
+         let new_recipe_category = next_account(&mut iter)?;
+         let crafting_domain = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let crafting_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(CompleteStarbaseUpgradeInstructionAccounts {
+             funder,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_facility,
+             upgrade_facility,
+             upgrade_recipe,
+             new_recipe_category,
+             crafting_domain,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+             system_program,
+         })
+diff --git a/src/instructions/create_cargo_pod.rs b/src/instructions/create_cargo_pod.rs
+index a8d1961..8e2bb8b 100644
+--- a/src/instructions/create_cargo_pod.rs
++++ b/src/instructions/create_cargo_pod.rs
+@@ -13,10 +13,17 @@ pub struct CreateCargoPod {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CreateCargoPodInstructionAccounts {
+     pub funder: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub cargo_pod: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub cargo_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -29,19 +36,35 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateCargoPod {
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funder = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let cargo_pod = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let cargo_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(CreateCargoPodInstructionAccounts {
+             funder,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             cargo_pod,
+             cargo_stats_definition,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             cargo_program,
+             system_program,
+         })
+diff --git a/src/instructions/create_starbase_upgrade_resource_process.rs b/src/instructions/create_starbase_upgrade_resource_process.rs
+index e0f3cb7..570cb61 100644
+--- a/src/instructions/create_starbase_upgrade_resource_process.rs
++++ b/src/instructions/create_starbase_upgrade_resource_process.rs
+@@ -13,13 +13,20 @@ pub struct CreateStarbaseUpgradeResourceProcess {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CreateStarbaseUpgradeResourceProcessInstructionAccounts {
+     pub funder: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub upgrade_facility: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_domain: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -32,25 +39,41 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateStarbaseUpgradeResource
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funder = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let upgrade_facility = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_domain = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let crafting_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(CreateStarbaseUpgradeResourceProcessInstructionAccounts {
+             funder,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             upgrade_facility,
+             crafting_process,
+             crafting_recipe,
+             crafting_domain,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+             system_program,
+         })
+diff --git a/src/instructions/deposit_starbase_upkeep_resource.rs b/src/instructions/deposit_starbase_upkeep_resource.rs
+index 1a3fe5d..f3f4a0b 100644
+--- a/src/instructions/deposit_starbase_upkeep_resource.rs
++++ b/src/instructions/deposit_starbase_upkeep_resource.rs
+@@ -13,15 +13,25 @@ pub struct DepositStarbaseUpkeepResource {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct DepositStarbaseUpkeepResourceInstructionAccounts {
+     pub funds_to: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub cargo_pod_from: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub resource_recipe: solana_pubkey::Pubkey,
+-    pub loyalty_points_accounts: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (loyalty)
++    pub loyalty_user_points_account: solana_pubkey::Pubkey,
++    pub loyalty_points_category: solana_pubkey::Pubkey,
++    pub loyalty_points_modifier_account: solana_pubkey::Pubkey,
+     pub progression_config: solana_pubkey::Pubkey,
+     pub points_program: solana_pubkey::Pubkey,
+     pub cargo_program: solana_pubkey::Pubkey,
+@@ -36,15 +46,31 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositStarbaseUpkeepResource
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funds_to = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let cargo_pod_from = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+         let token_from = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let resource_recipe = next_account(&mut iter)?;
+-        let loyalty_points_accounts = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (loyalty)
++        let loyalty_user_points_account = next_account(&mut iter)?;
++        let loyalty_points_category = next_account(&mut iter)?;
++        let loyalty_points_modifier_account = next_account(&mut iter)?;
++
+         let progression_config = next_account(&mut iter)?;
+         let points_program = next_account(&mut iter)?;
+         let cargo_program = next_account(&mut iter)?;
+@@ -52,15 +78,22 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositStarbaseUpkeepResource
+ 
+         Some(DepositStarbaseUpkeepResourceInstructionAccounts {
+             funds_to,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             cargo_pod_from,
+             cargo_type,
+             cargo_stats_definition,
+             token_from,
+             token_mint,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             resource_recipe,
+-            loyalty_points_accounts,
++            loyalty_user_points_account,
++            loyalty_points_category,
++            loyalty_points_modifier_account,
+             progression_config,
+             points_program,
+             cargo_program,
+diff --git a/src/instructions/start_starbase_upgrade.rs b/src/instructions/start_starbase_upgrade.rs
+index ca1a93a..5006403 100644
+--- a/src/instructions/start_starbase_upgrade.rs
++++ b/src/instructions/start_starbase_upgrade.rs
+@@ -13,10 +13,17 @@ pub struct StartStarbaseUpgrade {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StartStarbaseUpgradeInstructionAccounts {
+     pub funder: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub upgrade_facility: solana_pubkey::Pubkey,
+     pub upgrade_recipe: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -28,18 +35,34 @@ impl carbon_core::deserialize::ArrangeAccounts for StartStarbaseUpgrade {
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funder = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let upgrade_facility = next_account(&mut iter)?;
+         let upgrade_recipe = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(StartStarbaseUpgradeInstructionAccounts {
+             funder,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             upgrade_facility,
+             upgrade_recipe,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             system_program,
+         })
+     }
+diff --git a/src/instructions/submit_starbase_upgrade_resource.rs b/src/instructions/submit_starbase_upgrade_resource.rs
+index d740f42..bb8dae5 100644
+--- a/src/instructions/submit_starbase_upgrade_resource.rs
++++ b/src/instructions/submit_starbase_upgrade_resource.rs
+@@ -13,7 +13,9 @@ pub struct SubmitStarbaseUpgradeResource {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct SubmitStarbaseUpgradeResourceInstructionAccounts {
+     pub funds_to: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseMutAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub resource_crafting_instance: solana_pubkey::Pubkey,
+     pub resource_crafting_process: solana_pubkey::Pubkey,
+     pub resource_crafting_facility: solana_pubkey::Pubkey,
+@@ -26,8 +28,16 @@ pub struct SubmitStarbaseUpgradeResourceInstructionAccounts {
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+-    pub loyalty_points_accounts: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (loyalty)
++    pub loyalty_user_points_account: solana_pubkey::Pubkey,
++    pub loyalty_points_category: solana_pubkey::Pubkey,
++    pub loyalty_points_modifier_account: solana_pubkey::Pubkey,
+     pub progression_config: solana_pubkey::Pubkey,
+     pub points_program: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -43,7 +53,11 @@ impl carbon_core::deserialize::ArrangeAccounts for SubmitStarbaseUpgradeResource
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funds_to = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseMutAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let resource_crafting_instance = next_account(&mut iter)?;
+         let resource_crafting_process = next_account(&mut iter)?;
+         let resource_crafting_facility = next_account(&mut iter)?;
+@@ -56,8 +70,19 @@ impl carbon_core::deserialize::ArrangeAccounts for SubmitStarbaseUpgradeResource
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
+-        let loyalty_points_accounts = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (loyalty)
++        let loyalty_user_points_account = next_account(&mut iter)?;
++        let loyalty_points_category = next_account(&mut iter)?;
++        let loyalty_points_modifier_account = next_account(&mut iter)?;
++
+         let progression_config = next_account(&mut iter)?;
+         let points_program = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+@@ -66,7 +91,8 @@ impl carbon_core::deserialize::ArrangeAccounts for SubmitStarbaseUpgradeResource
+ 
+         Some(SubmitStarbaseUpgradeResourceInstructionAccounts {
+             funds_to,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             resource_crafting_instance,
+             resource_crafting_process,
+             resource_crafting_facility,
+@@ -79,8 +105,14 @@ impl carbon_core::deserialize::ArrangeAccounts for SubmitStarbaseUpgradeResource
+             token_from,
+             token_to,
+             token_mint,
+-            game_accounts_and_profile,
+-            loyalty_points_accounts,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
++            loyalty_user_points_account,
++            loyalty_points_category,
++            loyalty_points_modifier_account,
+             progression_config,
+             points_program,
+             crafting_program,
+diff --git a/src/instructions/sync_starbase_upgrade_ingredients.rs b/src/instructions/sync_starbase_upgrade_ingredients.rs
+index 281226c..8eb9704 100644
+--- a/src/instructions/sync_starbase_upgrade_ingredients.rs
++++ b/src/instructions/sync_starbase_upgrade_ingredients.rs
+@@ -15,7 +15,12 @@ pub struct SyncStarbaseUpgradeIngredientsInstructionAccounts {
+     pub funder: solana_pubkey::Pubkey,
+     pub starbase: solana_pubkey::Pubkey,
+     pub upgrade_recipe: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -29,14 +34,25 @@ impl carbon_core::deserialize::ArrangeAccounts for SyncStarbaseUpgradeIngredient
+         let funder = next_account(&mut iter)?;
+         let starbase = next_account(&mut iter)?;
+         let upgrade_recipe = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(SyncStarbaseUpgradeIngredientsInstructionAccounts {
+             funder,
+             starbase,
+             upgrade_recipe,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             system_program,
+         })
+     }


### PR DESCRIPTION
### TL;DR

Expanded composite account structures in starbase-related instructions to improve decoder clarity and accuracy.

### What changed?

This PR expands composite account structures in eight starbase-related instruction files:

- Expanded `starbase_and_starbase_player` into individual `starbase` and `starbase_player` accounts
- Expanded `game_accounts_and_profile` into `key`, `profile`, `profile_faction`, `game_id`, and `game_state` accounts
- Expanded `loyalty_points_accounts` into `loyalty_user_points_account`, `loyalty_points_category`, and `loyalty_points_modifier_account` in relevant files

The affected files are:
- `close_upgrade_process.rs`
- `complete_starbase_upgrade.rs`
- `create_cargo_pod.rs`
- `create_starbase_upgrade_resource_process.rs`
- `deposit_starbase_upkeep_resource.rs`
- `start_starbase_upgrade.rs`
- `submit_starbase_upgrade_resource.rs`
- `sync_starbase_upgrade_ingredients.rs`

### How to test?

1. Run the decoder against transactions that use these starbase-related instructions
2. Verify that the expanded account structures are correctly populated
3. Confirm that the decoder can properly identify and parse all accounts in these instructions

### Why make this change?

This change improves the decoder's ability to accurately represent the actual account structure used by the Sage program. By expanding composite accounts into their individual components, we gain:

1. Better visibility into the specific accounts being used
2. More accurate representation of the on-chain data structure
3. Improved debugging capabilities when analyzing transactions
4. Consistency with the actual program implementation

This is part of the ongoing effort to enhance the decoder's fidelity to the on-chain program structure.