### PR TITLE
feat: sage-holosim patch 07 instructions crafting

### DIFF
--- a/carbon-decoders/sage-holosim-decoder/src/instructions/burn_crafting_consumables.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/burn_crafting_consumables.rs
@@ -12,12 +12,16 @@ pub struct BurnCraftingConsumables {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BurnCraftingConsumablesInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
-    pub game_accounts: solana_pubkey::Pubkey,
+    // GameAndGameState expansion
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub token_from: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -31,24 +35,34 @@ impl carbon_core::deserialize::ArrangeAccounts for BurnCraftingConsumables {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
-        let game_accounts = next_account(&mut iter)?;
+
+        // GameAndGameState expansion
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let token_from = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
         let token_program = next_account(&mut iter)?;
 
         Some(BurnCraftingConsumablesInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_facility,
             crafting_recipe,
-            game_accounts,
+            game_id,
+            game_state,
             token_from,
             token_mint,
             crafting_program,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/cancel_crafting_process.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/cancel_crafting_process.rs
@@ -13,11 +13,18 @@ pub struct CancelCraftingProcess {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CancelCraftingProcessInstructionAccounts {
     pub funds_to: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
 }
 
@@ -29,20 +36,36 @@ impl carbon_core::deserialize::ArrangeAccounts for CancelCraftingProcess {
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funds_to = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let crafting_program = next_account(&mut iter)?;
 
         Some(CancelCraftingProcessInstructionAccounts {
             funds_to,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_facility,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
         })
     }

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/claim_crafting_non_consumables.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/claim_crafting_non_consumables.rs
@@ -12,7 +12,9 @@ pub struct ClaimCraftingNonConsumables {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ClaimCraftingNonConsumablesInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
@@ -20,7 +22,9 @@ pub struct ClaimCraftingNonConsumablesInstructionAccounts {
     pub cargo_pod_to: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts: solana_pubkey::Pubkey,
+    // GameAndGameState expansion
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
@@ -36,7 +40,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
@@ -44,7 +52,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
         let cargo_pod_to = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts = next_account(&mut iter)?;
+
+        // GameAndGameState expansion
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
@@ -53,7 +65,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
         let token_program = next_account(&mut iter)?;
 
         Some(ClaimCraftingNonConsumablesInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_facility,
@@ -61,7 +74,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
             cargo_pod_to,
             cargo_type,
             cargo_stats_definition,
-            game_accounts,
+            game_id,
+            game_state,
             token_from,
             token_to,
             token_mint,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/claim_crafting_outputs.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/claim_crafting_outputs.rs
@@ -12,7 +12,9 @@ pub struct ClaimCraftingOutputs {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ClaimCraftingOutputsInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
@@ -21,7 +23,9 @@ pub struct ClaimCraftingOutputsInstructionAccounts {
     pub cargo_pod_to: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts: solana_pubkey::Pubkey,
+    // GameAndGameState expansion
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -36,7 +40,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
@@ -45,7 +53,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
         let cargo_pod_to = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts = next_account(&mut iter)?;
+
+        // GameAndGameState expansion
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
@@ -53,7 +65,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
         let token_program = next_account(&mut iter)?;
 
         Some(ClaimCraftingOutputsInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_facility,
@@ -62,7 +75,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
             cargo_pod_to,
             cargo_type,
             cargo_stats_definition,
-            game_accounts,
+            game_id,
+            game_state,
             token_from,
             token_to,
             crafting_program,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/close_crafting_process.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/close_crafting_process.rs
@@ -13,14 +13,27 @@ pub struct CloseCraftingProcess {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CloseCraftingProcessInstructionAccounts {
     pub funds_to: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayerMut expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
-    pub crafting_xp_accounts: solana_pubkey::Pubkey,
-    pub council_rank_xp_accounts: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (crafting)
+    pub crafting_user_points_account: solana_pubkey::Pubkey,
+    pub crafting_points_category: solana_pubkey::Pubkey,
+    pub crafting_points_modifier_account: solana_pubkey::Pubkey,
+    // PointsModificationAccounts expansion (council_rank)
+    pub council_rank_user_points_account: solana_pubkey::Pubkey,
+    pub council_rank_points_category: solana_pubkey::Pubkey,
+    pub council_rank_points_modifier_account: solana_pubkey::Pubkey,
     pub progression_config: solana_pubkey::Pubkey,
     pub points_program: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -34,28 +47,56 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseCraftingProcess {
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funds_to = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayerMut expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
-        let crafting_xp_accounts = next_account(&mut iter)?;
-        let council_rank_xp_accounts = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (crafting)
+        let crafting_user_points_account = next_account(&mut iter)?;
+        let crafting_points_category = next_account(&mut iter)?;
+        let crafting_points_modifier_account = next_account(&mut iter)?;
+
+        // PointsModificationAccounts expansion (council_rank)
+        let council_rank_user_points_account = next_account(&mut iter)?;
+        let council_rank_points_category = next_account(&mut iter)?;
+        let council_rank_points_modifier_account = next_account(&mut iter)?;
+
         let progression_config = next_account(&mut iter)?;
         let points_program = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
 
         Some(CloseCraftingProcessInstructionAccounts {
             funds_to,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_recipe,
             crafting_facility,
-            game_accounts_and_profile,
-            crafting_xp_accounts,
-            council_rank_xp_accounts,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
+            crafting_user_points_account,
+            crafting_points_category,
+            crafting_points_modifier_account,
+            council_rank_user_points_account,
+            council_rank_points_category,
+            council_rank_points_modifier_account,
             progression_config,
             points_program,
             crafting_program,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/create_crafting_process.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/create_crafting_process.rs
@@ -13,13 +13,20 @@ pub struct CreateCraftingProcess {
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CreateCraftingProcessInstructionAccounts {
     pub funder: solana_pubkey::Pubkey,
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_domain: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
     pub system_program: solana_pubkey::Pubkey,
 }
@@ -32,25 +39,41 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateCraftingProcess {
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let funder = next_account(&mut iter)?;
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_domain = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let crafting_program = next_account(&mut iter)?;
         let system_program = next_account(&mut iter)?;
 
         Some(CreateCraftingProcessInstructionAccounts {
             funder,
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_facility,
             crafting_process,
             crafting_recipe,
             crafting_domain,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
             system_program,
         })

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/deposit_crafting_ingredient.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/deposit_crafting_ingredient.rs
@@ -12,7 +12,9 @@ pub struct DepositCraftingIngredient {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DepositCraftingIngredientInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
@@ -20,7 +22,12 @@ pub struct DepositCraftingIngredientInstructionAccounts {
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
@@ -35,7 +42,11 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
@@ -43,7 +54,14 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
         let crafting_recipe = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let crafting_program = next_account(&mut iter)?;
@@ -51,7 +69,8 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
         let token_program = next_account(&mut iter)?;
 
         Some(DepositCraftingIngredientInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_facility,
             crafting_process,
@@ -59,7 +78,11 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
             crafting_recipe,
             cargo_type,
             cargo_stats_definition,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             token_from,
             token_to,
             crafting_program,

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/start_crafting_process.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/start_crafting_process.rs
@@ -12,12 +12,19 @@ pub struct StartCraftingProcess {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StartCraftingProcessInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
 }
 
@@ -28,21 +35,37 @@ impl carbon_core::deserialize::ArrangeAccounts for StartCraftingProcess {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let crafting_program = next_account(&mut iter)?;
 
         Some(StartCraftingProcessInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_recipe,
             crafting_facility,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
         })
     }

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/stop_crafting_process.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/stop_crafting_process.rs
@@ -12,12 +12,19 @@ pub struct StopCraftingProcess {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StopCraftingProcessInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub crafting_program: solana_pubkey::Pubkey,
 }
 
@@ -28,21 +35,37 @@ impl carbon_core::deserialize::ArrangeAccounts for StopCraftingProcess {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
         let crafting_recipe = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let crafting_program = next_account(&mut iter)?;
 
         Some(StopCraftingProcessInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_process,
             crafting_recipe,
             crafting_facility,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             crafting_program,
         })
     }

--- a/carbon-decoders/sage-holosim-decoder/src/instructions/withdraw_crafting_ingredient.rs
+++ b/carbon-decoders/sage-holosim-decoder/src/instructions/withdraw_crafting_ingredient.rs
@@ -12,7 +12,9 @@ pub struct WithdrawCraftingIngredient {
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct WithdrawCraftingIngredientInstructionAccounts {
-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
+    // StarbaseAndStarbasePlayer expansion
+    pub starbase: solana_pubkey::Pubkey,
+    pub starbase_player: solana_pubkey::Pubkey,
     pub crafting_instance: solana_pubkey::Pubkey,
     pub crafting_facility: solana_pubkey::Pubkey,
     pub crafting_process: solana_pubkey::Pubkey,
@@ -20,7 +22,12 @@ pub struct WithdrawCraftingIngredientInstructionAccounts {
     pub crafting_recipe: solana_pubkey::Pubkey,
     pub cargo_type: solana_pubkey::Pubkey,
     pub cargo_stats_definition: solana_pubkey::Pubkey,
-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+    // GameAndGameStateAndProfile expansion
+    pub key: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub profile_faction: solana_pubkey::Pubkey,
+    pub game_id: solana_pubkey::Pubkey,
+    pub game_state: solana_pubkey::Pubkey,
     pub token_from: solana_pubkey::Pubkey,
     pub token_to: solana_pubkey::Pubkey,
     pub token_mint: solana_pubkey::Pubkey,
@@ -36,7 +43,11 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
         accounts: &[solana_instruction::AccountMeta],
     ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
-        let starbase_and_starbase_player = next_account(&mut iter)?;
+
+        // StarbaseAndStarbasePlayer expansion
+        let starbase = next_account(&mut iter)?;
+        let starbase_player = next_account(&mut iter)?;
+
         let crafting_instance = next_account(&mut iter)?;
         let crafting_facility = next_account(&mut iter)?;
         let crafting_process = next_account(&mut iter)?;
@@ -44,7 +55,14 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
         let crafting_recipe = next_account(&mut iter)?;
         let cargo_type = next_account(&mut iter)?;
         let cargo_stats_definition = next_account(&mut iter)?;
-        let game_accounts_and_profile = next_account(&mut iter)?;
+
+        // GameAndGameStateAndProfile expansion
+        let key = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let profile_faction = next_account(&mut iter)?;
+        let game_id = next_account(&mut iter)?;
+        let game_state = next_account(&mut iter)?;
+
         let token_from = next_account(&mut iter)?;
         let token_to = next_account(&mut iter)?;
         let token_mint = next_account(&mut iter)?;
@@ -53,7 +71,8 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
         let token_program = next_account(&mut iter)?;
 
         Some(WithdrawCraftingIngredientInstructionAccounts {
-            starbase_and_starbase_player,
+            starbase,
+            starbase_player,
             crafting_instance,
             crafting_facility,
             crafting_process,
@@ -61,7 +80,11 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
             crafting_recipe,
             cargo_type,
             cargo_stats_definition,
-            game_accounts_and_profile,
+            key,
+            profile,
+            profile_faction,
+            game_id,
+            game_state,
             token_from,
             token_to,
             token_mint,

--- a/docs/sage-holosim-patching-plan.md
+++ b/docs/sage-holosim-patching-plan.md
@@ -5,12 +5,12 @@ This document outlines the complete patching strategy for expanding composite ac
 
 ## Progress Summary
 - **Total instruction files**: 124
-- **Completed patches**: 6 (covering 18 instruction files + 2 account files)
-- **Files needing composite expansions**: ~77 remaining
-- **Remaining patches**: ~11
+- **Completed patches**: 7 (covering 28 instruction files + 2 account files)
+- **Files needing composite expansions**: ~67 remaining
+- **Remaining patches**: ~10
 - **Estimated total patches**: ~17
 
-## Completed Patches (01-06)
+## Completed Patches (01-07)
 
 ### Patch 01: Disable Combat Log Events
 - **Files**: 2 (combat_log_event.rs, combat_resolved_event.rs) + mod.rs updates
@@ -81,14 +81,8 @@ This document outlines the complete patching strategy for expanding composite ac
 - **Status**: ✅ Complete (578 lines)
 - **Note**: repair_starbase.rs deferred to Patch 10 Combat Operations (uses `game_and_fleet_and_owner` composite)
 
----
-
-## Remaining Patches (07-17)
-
-### Priority 2: Frequently Used Operations (Medium-High Priority)
-
-#### Patch 07: Crafting Instructions
-- **Files**: ~10
+### Patch 07: Crafting Instructions
+- **Files**: 10
   - deposit_crafting_ingredient.rs
   - withdraw_crafting_ingredient.rs
   - start_crafting_process.rs
@@ -102,10 +96,17 @@ This document outlines the complete patching strategy for expanding composite ac
 - **Composite accounts**:
   - `starbase_and_starbase_player` → StarbaseMutAndStarbasePlayer (2 accounts)
   - `game_accounts_and_profile` → GameAndGameStateAndProfile (5 accounts)
-  - PointsModificationAccounts in close_crafting_process.rs
+  - `game_accounts` → GameAndGameState (2 accounts) - claim/burn files only
+  - PointsModificationAccounts (2 instances in close_crafting_process.rs): crafting_, council_rank_
 - **Complexity**: Medium-High
 - **Priority**: 🟡 Medium-High - Core crafting system
-- **Status**: 🔲 Pending
+- **Status**: ✅ Complete (744 lines)
+
+---
+
+## Remaining Patches (08-17)
+
+### Priority 2: Frequently Used Operations (Medium-High Priority)
 
 #### Patch 08: Fleet Management & State Transitions
 - **Files**: ~15
@@ -328,10 +329,11 @@ This document outlines the complete patching strategy for expanding composite ac
 
 ### Pattern 6: GameAndProfileAndFaction
 **Field name**: `game_and_profile_and_faction`
-**Expands to** (3 accounts):
+**Expands to** (4 accounts):
 - `key` - Game account/signer
 - `profile` - Player profile
 - `profile_faction` - Profile faction
+- `game_id` - Game ID
 
 ### Pattern 7: GameAndFleetAndOwner (Combat Variant)
 **Field name**: `game_and_fleet_and_owner`
@@ -360,8 +362,8 @@ This document outlines the complete patching strategy for expanding composite ac
 4. ~~**Patch 04** - Mining Operations~~ ✅ Complete
 5. ~~**Patch 05** - Movement Instructions~~ ✅ Complete
 6. ~~**Patch 06** - Starbase Operations~~ ✅ Complete
-7. **Patch 07** - Crafting Instructions - **NEXT**
-8. **Patch 08** - Fleet Management
+7. ~~**Patch 07** - Crafting Instructions~~ ✅ Complete
+8. **Patch 08** - Fleet Management - **NEXT**
 9. **Patch 09** - Fleet Cargo Operations
 10. **Patch 10** - Combat Operations
 11. **Patch 11** - Ship & Crew Management

--- a/patches/sage-holosim-07-instructions-crafting.patch
+++ b/patches/sage-holosim-07-instructions-crafting.patch
@@ -1,0 +1,744 @@
+diff --git a/src/instructions/burn_crafting_consumables.rs b/src/instructions/burn_crafting_consumables.rs
+index 897153a..f692cad 100644
+--- a/src/instructions/burn_crafting_consumables.rs
++++ b/src/instructions/burn_crafting_consumables.rs
+@@ -12,12 +12,16 @@ pub struct BurnCraftingConsumables {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct BurnCraftingConsumablesInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -31,24 +35,34 @@ impl carbon_core::deserialize::ArrangeAccounts for BurnCraftingConsumables {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let token_from = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(BurnCraftingConsumablesInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_facility,
+             crafting_recipe,
+-            game_accounts,
++            game_id,
++            game_state,
+             token_from,
+             token_mint,
+             crafting_program,
+diff --git a/src/instructions/cancel_crafting_process.rs b/src/instructions/cancel_crafting_process.rs
+index f66e97d..6f3ebfc 100644
+--- a/src/instructions/cancel_crafting_process.rs
++++ b/src/instructions/cancel_crafting_process.rs
+@@ -13,11 +13,18 @@ pub struct CancelCraftingProcess {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CancelCraftingProcessInstructionAccounts {
+     pub funds_to: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -29,20 +36,36 @@ impl carbon_core::deserialize::ArrangeAccounts for CancelCraftingProcess {
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funds_to = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(CancelCraftingProcessInstructionAccounts {
+             funds_to,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_facility,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+         })
+     }
+diff --git a/src/instructions/claim_crafting_non_consumables.rs b/src/instructions/claim_crafting_non_consumables.rs
+index 4154597..1439886 100644
+--- a/src/instructions/claim_crafting_non_consumables.rs
++++ b/src/instructions/claim_crafting_non_consumables.rs
+@@ -12,7 +12,9 @@ pub struct ClaimCraftingNonConsumables {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct ClaimCraftingNonConsumablesInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+@@ -20,7 +22,9 @@ pub struct ClaimCraftingNonConsumablesInstructionAccounts {
+     pub cargo_pod_to: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+@@ -36,7 +40,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+@@ -44,7 +52,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
+         let cargo_pod_to = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+@@ -53,7 +65,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(ClaimCraftingNonConsumablesInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_facility,
+@@ -61,7 +74,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingNonConsumables {
+             cargo_pod_to,
+             cargo_type,
+             cargo_stats_definition,
+-            game_accounts,
++            game_id,
++            game_state,
+             token_from,
+             token_to,
+             token_mint,
+diff --git a/src/instructions/claim_crafting_outputs.rs b/src/instructions/claim_crafting_outputs.rs
+index dcb2695..456f530 100644
+--- a/src/instructions/claim_crafting_outputs.rs
++++ b/src/instructions/claim_crafting_outputs.rs
+@@ -12,7 +12,9 @@ pub struct ClaimCraftingOutputs {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct ClaimCraftingOutputsInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+@@ -21,7 +23,9 @@ pub struct ClaimCraftingOutputsInstructionAccounts {
+     pub cargo_pod_to: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts: solana_pubkey::Pubkey,
++    // GameAndGameState expansion
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -36,7 +40,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+@@ -45,7 +53,11 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
+         let cargo_pod_to = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts = next_account(&mut iter)?;
++
++        // GameAndGameState expansion
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+@@ -53,7 +65,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(ClaimCraftingOutputsInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_facility,
+@@ -62,7 +75,8 @@ impl carbon_core::deserialize::ArrangeAccounts for ClaimCraftingOutputs {
+             cargo_pod_to,
+             cargo_type,
+             cargo_stats_definition,
+-            game_accounts,
++            game_id,
++            game_state,
+             token_from,
+             token_to,
+             crafting_program,
+diff --git a/src/instructions/close_crafting_process.rs b/src/instructions/close_crafting_process.rs
+index 2d39a21..95cc974 100644
+--- a/src/instructions/close_crafting_process.rs
++++ b/src/instructions/close_crafting_process.rs
+@@ -13,14 +13,27 @@ pub struct CloseCraftingProcess {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CloseCraftingProcessInstructionAccounts {
+     pub funds_to: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayerMut expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
+-    pub crafting_xp_accounts: solana_pubkey::Pubkey,
+-    pub council_rank_xp_accounts: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (crafting)
++    pub crafting_user_points_account: solana_pubkey::Pubkey,
++    pub crafting_points_category: solana_pubkey::Pubkey,
++    pub crafting_points_modifier_account: solana_pubkey::Pubkey,
++    // PointsModificationAccounts expansion (council_rank)
++    pub council_rank_user_points_account: solana_pubkey::Pubkey,
++    pub council_rank_points_category: solana_pubkey::Pubkey,
++    pub council_rank_points_modifier_account: solana_pubkey::Pubkey,
+     pub progression_config: solana_pubkey::Pubkey,
+     pub points_program: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -34,28 +47,56 @@ impl carbon_core::deserialize::ArrangeAccounts for CloseCraftingProcess {
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funds_to = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayerMut expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
+-        let crafting_xp_accounts = next_account(&mut iter)?;
+-        let council_rank_xp_accounts = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (crafting)
++        let crafting_user_points_account = next_account(&mut iter)?;
++        let crafting_points_category = next_account(&mut iter)?;
++        let crafting_points_modifier_account = next_account(&mut iter)?;
++
++        // PointsModificationAccounts expansion (council_rank)
++        let council_rank_user_points_account = next_account(&mut iter)?;
++        let council_rank_points_category = next_account(&mut iter)?;
++        let council_rank_points_modifier_account = next_account(&mut iter)?;
++
+         let progression_config = next_account(&mut iter)?;
+         let points_program = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(CloseCraftingProcessInstructionAccounts {
+             funds_to,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_recipe,
+             crafting_facility,
+-            game_accounts_and_profile,
+-            crafting_xp_accounts,
+-            council_rank_xp_accounts,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
++            crafting_user_points_account,
++            crafting_points_category,
++            crafting_points_modifier_account,
++            council_rank_user_points_account,
++            council_rank_points_category,
++            council_rank_points_modifier_account,
+             progression_config,
+             points_program,
+             crafting_program,
+diff --git a/src/instructions/create_crafting_process.rs b/src/instructions/create_crafting_process.rs
+index 362d7f5..7639f70 100644
+--- a/src/instructions/create_crafting_process.rs
++++ b/src/instructions/create_crafting_process.rs
+@@ -13,13 +13,20 @@ pub struct CreateCraftingProcess {
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct CreateCraftingProcessInstructionAccounts {
+     pub funder: solana_pubkey::Pubkey,
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_domain: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+     pub system_program: solana_pubkey::Pubkey,
+ }
+@@ -32,25 +39,41 @@ impl carbon_core::deserialize::ArrangeAccounts for CreateCraftingProcess {
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+         let funder = next_account(&mut iter)?;
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_domain = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let crafting_program = next_account(&mut iter)?;
+         let system_program = next_account(&mut iter)?;
+ 
+         Some(CreateCraftingProcessInstructionAccounts {
+             funder,
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_facility,
+             crafting_process,
+             crafting_recipe,
+             crafting_domain,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+             system_program,
+         })
+diff --git a/src/instructions/deposit_crafting_ingredient.rs b/src/instructions/deposit_crafting_ingredient.rs
+index 61bb970..6580a26 100644
+--- a/src/instructions/deposit_crafting_ingredient.rs
++++ b/src/instructions/deposit_crafting_ingredient.rs
+@@ -12,7 +12,9 @@ pub struct DepositCraftingIngredient {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct DepositCraftingIngredientInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+@@ -20,7 +22,12 @@ pub struct DepositCraftingIngredientInstructionAccounts {
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+@@ -35,7 +42,11 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+@@ -43,7 +54,14 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
+         let crafting_recipe = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let crafting_program = next_account(&mut iter)?;
+@@ -51,7 +69,8 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(DepositCraftingIngredientInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_facility,
+             crafting_process,
+@@ -59,7 +78,11 @@ impl carbon_core::deserialize::ArrangeAccounts for DepositCraftingIngredient {
+             crafting_recipe,
+             cargo_type,
+             cargo_stats_definition,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             token_from,
+             token_to,
+             crafting_program,
+diff --git a/src/instructions/start_crafting_process.rs b/src/instructions/start_crafting_process.rs
+index 589506b..ce130a1 100644
+--- a/src/instructions/start_crafting_process.rs
++++ b/src/instructions/start_crafting_process.rs
+@@ -12,12 +12,19 @@ pub struct StartCraftingProcess {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StartCraftingProcessInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -28,21 +35,37 @@ impl carbon_core::deserialize::ArrangeAccounts for StartCraftingProcess {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(StartCraftingProcessInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_recipe,
+             crafting_facility,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+         })
+     }
+diff --git a/src/instructions/stop_crafting_process.rs b/src/instructions/stop_crafting_process.rs
+index 35af4eb..ace6d3b 100644
+--- a/src/instructions/stop_crafting_process.rs
++++ b/src/instructions/stop_crafting_process.rs
+@@ -12,12 +12,19 @@ pub struct StopCraftingProcess {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct StopCraftingProcessInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub crafting_program: solana_pubkey::Pubkey,
+ }
+ 
+@@ -28,21 +35,37 @@ impl carbon_core::deserialize::ArrangeAccounts for StopCraftingProcess {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+         let crafting_recipe = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let crafting_program = next_account(&mut iter)?;
+ 
+         Some(StopCraftingProcessInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_process,
+             crafting_recipe,
+             crafting_facility,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             crafting_program,
+         })
+     }
+diff --git a/src/instructions/withdraw_crafting_ingredient.rs b/src/instructions/withdraw_crafting_ingredient.rs
+index e89b47e..da0b48b 100644
+--- a/src/instructions/withdraw_crafting_ingredient.rs
++++ b/src/instructions/withdraw_crafting_ingredient.rs
+@@ -12,7 +12,9 @@ pub struct WithdrawCraftingIngredient {
+ 
+ #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+ pub struct WithdrawCraftingIngredientInstructionAccounts {
+-    pub starbase_and_starbase_player: solana_pubkey::Pubkey,
++    // StarbaseAndStarbasePlayer expansion
++    pub starbase: solana_pubkey::Pubkey,
++    pub starbase_player: solana_pubkey::Pubkey,
+     pub crafting_instance: solana_pubkey::Pubkey,
+     pub crafting_facility: solana_pubkey::Pubkey,
+     pub crafting_process: solana_pubkey::Pubkey,
+@@ -20,7 +22,12 @@ pub struct WithdrawCraftingIngredientInstructionAccounts {
+     pub crafting_recipe: solana_pubkey::Pubkey,
+     pub cargo_type: solana_pubkey::Pubkey,
+     pub cargo_stats_definition: solana_pubkey::Pubkey,
+-    pub game_accounts_and_profile: solana_pubkey::Pubkey,
++    // GameAndGameStateAndProfile expansion
++    pub key: solana_pubkey::Pubkey,
++    pub profile: solana_pubkey::Pubkey,
++    pub profile_faction: solana_pubkey::Pubkey,
++    pub game_id: solana_pubkey::Pubkey,
++    pub game_state: solana_pubkey::Pubkey,
+     pub token_from: solana_pubkey::Pubkey,
+     pub token_to: solana_pubkey::Pubkey,
+     pub token_mint: solana_pubkey::Pubkey,
+@@ -36,7 +43,11 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
+         accounts: &[solana_instruction::AccountMeta],
+     ) -> Option<Self::ArrangedAccounts> {
+         let mut iter = accounts.iter();
+-        let starbase_and_starbase_player = next_account(&mut iter)?;
++
++        // StarbaseAndStarbasePlayer expansion
++        let starbase = next_account(&mut iter)?;
++        let starbase_player = next_account(&mut iter)?;
++
+         let crafting_instance = next_account(&mut iter)?;
+         let crafting_facility = next_account(&mut iter)?;
+         let crafting_process = next_account(&mut iter)?;
+@@ -44,7 +55,14 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
+         let crafting_recipe = next_account(&mut iter)?;
+         let cargo_type = next_account(&mut iter)?;
+         let cargo_stats_definition = next_account(&mut iter)?;
+-        let game_accounts_and_profile = next_account(&mut iter)?;
++
++        // GameAndGameStateAndProfile expansion
++        let key = next_account(&mut iter)?;
++        let profile = next_account(&mut iter)?;
++        let profile_faction = next_account(&mut iter)?;
++        let game_id = next_account(&mut iter)?;
++        let game_state = next_account(&mut iter)?;
++
+         let token_from = next_account(&mut iter)?;
+         let token_to = next_account(&mut iter)?;
+         let token_mint = next_account(&mut iter)?;
+@@ -53,7 +71,8 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
+         let token_program = next_account(&mut iter)?;
+ 
+         Some(WithdrawCraftingIngredientInstructionAccounts {
+-            starbase_and_starbase_player,
++            starbase,
++            starbase_player,
+             crafting_instance,
+             crafting_facility,
+             crafting_process,
+@@ -61,7 +80,11 @@ impl carbon_core::deserialize::ArrangeAccounts for WithdrawCraftingIngredient {
+             crafting_recipe,
+             cargo_type,
+             cargo_stats_definition,
+-            game_accounts_and_profile,
++            key,
++            profile,
++            profile_faction,
++            game_id,
++            game_state,
+             token_from,
+             token_to,
+             token_mint,


### PR DESCRIPTION
### TL;DR

Expanded composite account fields in crafting instruction decoders to improve transaction data visibility.

### What changed?

This PR expands composite account fields in all crafting-related instruction decoders:

- Expanded `starbase_and_starbase_player` into separate `starbase` and `starbase_player` fields
- Expanded `game_accounts` into `game_id` and `game_state` fields
- Expanded `game_accounts_and_profile` into `key`, `profile`, `profile_faction`, `game_id`, and `game_state` fields
- Expanded `crafting_xp_accounts` and `council_rank_xp_accounts` in `close_crafting_process.rs` into their component fields for points modification accounts

All changes maintain the same functionality while providing more granular access to account data.

### How to test?

1. Run the decoder against crafting-related transactions
2. Verify that the expanded account fields are correctly populated
3. Confirm that all crafting instructions (deposit, withdraw, start, stop, claim, etc.) work as expected with the new account structure

### Why make this change?

This change improves transaction data visibility by exposing individual account fields that were previously bundled into composite fields. This makes it easier to:

1. Understand the relationship between accounts in crafting operations
2. Track specific accounts across different transactions
3. Debug issues related to crafting operations
4. Provide more detailed information in analytics and monitoring tools

The expanded fields follow the same pattern as previous patches, ensuring consistency across the codebase.