### PR TITLE
feat: add marketplace-decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "marketplace-decoder"
+version = "0.10.0"
+dependencies = [
+ "carbon-core",
+ "carbon-macros",
+ "carbon-proc-macros",
+ "serde",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/README.md
+++ b/README.md
@@ -19,12 +19,17 @@ This project generates and maintains Rust decoders for Star Atlas programs on So
 - **atlas-staking**: Atlas Staking program (`ATLocKpzDbTokxgvnLew3d7drZkEzLzDpzwgrgWKDbmc`)
   - Fetches IDL directly from Solana mainnet
   - ATLAS token staking with configurable rewards and cooldown periods
-  - No custom patches needed - straightforward account structures
+  - Minimal patches needed - adds serialization support for account types
 
 - **locked-voter**: Locked Voter program (`Lock7kBijGCQLEFAmXcengzXKA88iDNQPriQ7TbgeyG`)
   - Fetches IDL directly from Solana mainnet
   - POLIS governance and voting with escrow and whitelist controls
-  - No custom patches needed - straightforward account structures
+  - Minimal patches needed - adds serialization support for account types
+
+- **marketplace**: Galactic Marketplace program (`traderDnaR5w6Tcoi3NFm53i48FTDNbGjBSZwWXDRrg`)
+  - Fetches IDL directly from Solana mainnet
+  - NFT marketplace with order books, currency management, and royalty tiers
+  - Minimal patches needed - adds serialization support for account types
 
 ## Prerequisites
 
@@ -49,6 +54,7 @@ just all-sage-starbased
 just all-sage-holosim
 just all-atlas-staking
 just all-locked-voter
+just all-marketplace
 ```
 
 ## Project Structure
@@ -59,7 +65,8 @@ star-atlas-decoders/
 │   ├── sage-starbased-decoder/
 │   ├── sage-holosim-decoder/
 │   ├── atlas-staking-decoder/
-│   └── locked-voter-decoder/
+│   ├── locked-voter-decoder/
+│   └── marketplace-decoder/
 ├── dist/                    # Temporary build directory (gitignored)
 ├── patches/                 # Custom patches for decoders
 │   ├── sage-starbased-01-accounts.patch
@@ -143,6 +150,7 @@ cargo check -p sage-starbased-decoder
 cargo check -p sage-holosim-decoder
 cargo check -p atlas-staking-decoder
 cargo check -p locked-voter-decoder
+cargo check -p marketplace-decoder
 
 # Run clippy
 cargo clippy --all-targets --all-features -- -D warnings
@@ -159,6 +167,7 @@ just clean-sage-starbased
 just clean-sage-holosim
 just clean-atlas-staking
 just clean-locked-voter
+just clean-marketplace
 just clean-all
 
 # List available patches

--- a/carbon-decoders/marketplace-decoder/Cargo.toml
+++ b/carbon-decoders/marketplace-decoder/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "marketplace-decoder"
+version = "0.10.0"
+edition = "2024"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+carbon-core = "0.10.0"
+carbon-proc-macros = "0.10.0"
+carbon-macros = "0.10.0"
+solana-account = "2.2.1"
+solana-instruction = { version = "2.3.0", default-features = false }
+solana-pubkey = { version = "2.4.0", features = ["borsh", "serde", "bytemuck"] }
+serde = { version = "1.0", features = ["derive"] }
+

--- a/carbon-decoders/marketplace-decoder/src/accounts/atlas_rate_account.rs
+++ b/carbon-decoders/marketplace-decoder/src/accounts/atlas_rate_account.rs
@@ -1,0 +1,9 @@
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf6abe890daec21a1")]
+pub struct AtlasRateAccount {
+    pub atlas_rate: u64,
+}

--- a/carbon-decoders/marketplace-decoder/src/accounts/fee_reduction.rs
+++ b/carbon-decoders/marketplace-decoder/src/accounts/fee_reduction.rs
@@ -1,0 +1,11 @@
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xbbf8b502b7a542af")]
+pub struct FeeReduction {
+    pub account: solana_pubkey::Pubkey,
+    pub bump: u8,
+    pub discount: u64,
+}

--- a/carbon-decoders/marketplace-decoder/src/accounts/market_vars.rs
+++ b/carbon-decoders/marketplace-decoder/src/accounts/market_vars.rs
@@ -1,0 +1,10 @@
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xff8e86193801db7c")]
+pub struct MarketVars {
+    pub update_authority_master: solana_pubkey::Pubkey,
+    pub bump: u8,
+}

--- a/carbon-decoders/marketplace-decoder/src/accounts/mod.rs
+++ b/carbon-decoders/marketplace-decoder/src/accounts/mod.rs
@@ -1,0 +1,101 @@
+use carbon_core::account::AccountDecoder;
+use carbon_core::deserialize::CarbonDeserialize;
+
+use super::MarketplaceDecoder;
+pub mod atlas_rate_account;
+pub mod fee_reduction;
+pub mod market_vars;
+pub mod open_orders_counter;
+pub mod order_account;
+pub mod registered_currency;
+
+#[derive(Debug, serde::Serialize)]
+pub enum MarketplaceAccount {
+    AtlasRateAccount(atlas_rate_account::AtlasRateAccount),
+    FeeReduction(fee_reduction::FeeReduction),
+    MarketVars(market_vars::MarketVars),
+    OpenOrdersCounter(open_orders_counter::OpenOrdersCounter),
+    OrderAccount(order_account::OrderAccount),
+    RegisteredCurrency(registered_currency::RegisteredCurrency),
+}
+
+impl<'a> AccountDecoder<'a> for MarketplaceDecoder {
+    type AccountType = MarketplaceAccount;
+    fn decode_account(
+        &self,
+        account: &solana_account::Account,
+    ) -> Option<carbon_core::account::DecodedAccount<Self::AccountType>> {
+        if let Some(decoded_account) =
+            atlas_rate_account::AtlasRateAccount::deserialize(account.data.as_slice())
+        {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: MarketplaceAccount::AtlasRateAccount(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        if let Some(decoded_account) =
+            fee_reduction::FeeReduction::deserialize(account.data.as_slice())
+        {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: MarketplaceAccount::FeeReduction(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        if let Some(decoded_account) = market_vars::MarketVars::deserialize(account.data.as_slice())
+        {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: MarketplaceAccount::MarketVars(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        if let Some(decoded_account) =
+            open_orders_counter::OpenOrdersCounter::deserialize(account.data.as_slice())
+        {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: MarketplaceAccount::OpenOrdersCounter(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        if let Some(decoded_account) =
+            order_account::OrderAccount::deserialize(account.data.as_slice())
+        {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: MarketplaceAccount::OrderAccount(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        if let Some(decoded_account) =
+            registered_currency::RegisteredCurrency::deserialize(account.data.as_slice())
+        {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: MarketplaceAccount::RegisteredCurrency(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        None
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/accounts/open_orders_counter.rs
+++ b/carbon-decoders/marketplace-decoder/src/accounts/open_orders_counter.rs
@@ -1,0 +1,10 @@
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf57031812e21b749")]
+pub struct OpenOrdersCounter {
+    pub open_order_count: u64,
+    pub bump: u8,
+}

--- a/carbon-decoders/marketplace-decoder/src/accounts/order_account.rs
+++ b/carbon-decoders/marketplace-decoder/src/accounts/order_account.rs
@@ -1,0 +1,20 @@
+use super::super::types::*;
+
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x4f43709bd60e2037")]
+pub struct OrderAccount {
+    pub order_initializer_pubkey: solana_pubkey::Pubkey,
+    pub currency_mint: solana_pubkey::Pubkey,
+    pub asset_mint: solana_pubkey::Pubkey,
+    pub initializer_currency_token_account: solana_pubkey::Pubkey,
+    pub initializer_asset_token_account: solana_pubkey::Pubkey,
+    pub order_side: OrderSide,
+    pub price: u64,
+    pub order_origination_qty: u64,
+    pub order_remaining_qty: u64,
+    pub created_at_timestamp: i64,
+}

--- a/carbon-decoders/marketplace-decoder/src/accounts/registered_currency.rs
+++ b/carbon-decoders/marketplace-decoder/src/accounts/registered_currency.rs
@@ -1,0 +1,15 @@
+use super::super::types::*;
+
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x3c72f48610a63395")]
+pub struct RegisteredCurrency {
+    pub token_mint: solana_pubkey::Pubkey,
+    pub sa_currency_vault: solana_pubkey::Pubkey,
+    pub royalty: u64,
+    pub bump: u8,
+    pub royalty_tiers: Vec<RoyaltyTier>,
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/add_fee_exemption.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/add_fee_exemption.rs
@@ -1,0 +1,44 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xbdee65b6ee2f5d1e")]
+pub struct AddFeeExemption {
+    pub discount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct AddFeeExemptionInstructionAccounts {
+    pub update_authority_master: solana_pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub fee_exempt_target: solana_pubkey::Pubkey,
+    pub fee_exempt_account: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for AddFeeExemption {
+    type ArrangedAccounts = AddFeeExemptionInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_master = next_account(&mut iter)?;
+        let funder = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let fee_exempt_target = next_account(&mut iter)?;
+        let fee_exempt_account = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(AddFeeExemptionInstructionAccounts {
+            update_authority_master,
+            funder,
+            market_vars_account,
+            fee_exempt_target,
+            fee_exempt_account,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/add_royalty_tier.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/add_royalty_tier.rs
@@ -1,0 +1,36 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xe92155608e74f042")]
+pub struct AddRoyaltyTier {
+    pub stake_amount: u64,
+    pub discount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct AddRoyaltyTierInstructionAccounts {
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for AddRoyaltyTier {
+    type ArrangedAccounts = AddRoyaltyTierInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+
+        Some(AddRoyaltyTierInstructionAccounts {
+            update_authority_account,
+            market_vars_account,
+            registered_currency,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/delete_royalty_tier.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/delete_royalty_tier.rs
@@ -1,0 +1,35 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x4a515e9d669cbc6d")]
+pub struct DeleteRoyaltyTier {
+    pub stake_amount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct DeleteRoyaltyTierInstructionAccounts {
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for DeleteRoyaltyTier {
+    type ArrangedAccounts = DeleteRoyaltyTierInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+
+        Some(DeleteRoyaltyTierInstructionAccounts {
+            update_authority_account,
+            market_vars_account,
+            registered_currency,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/deregister_currency.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/deregister_currency.rs
@@ -1,0 +1,39 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xbde9211937d81c5a")]
+pub struct DeregisterCurrency {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct DeregisterCurrencyInstructionAccounts {
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+    pub currency_mint: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for DeregisterCurrency {
+    type ArrangedAccounts = DeregisterCurrencyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+        let currency_mint = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(DeregisterCurrencyInstructionAccounts {
+            update_authority_account,
+            market_vars_account,
+            registered_currency,
+            currency_mint,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/initialize_marketplace.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/initialize_marketplace.rs
@@ -1,0 +1,33 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x2f51400060386907")]
+pub struct InitializeMarketplace {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct InitializeMarketplaceInstructionAccounts {
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for InitializeMarketplace {
+    type ArrangedAccounts = InitializeMarketplaceInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(InitializeMarketplaceInstructionAccounts {
+            update_authority_account,
+            market_vars_account,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/initialize_open_orders_counter.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/initialize_open_orders_counter.rs
@@ -1,0 +1,39 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xdd86054c0491ca1d")]
+pub struct InitializeOpenOrdersCounter {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct InitializeOpenOrdersCounterInstructionAccounts {
+    pub payer: solana_pubkey::Pubkey,
+    pub user: solana_pubkey::Pubkey,
+    pub open_orders_counter: solana_pubkey::Pubkey,
+    pub deposit_mint: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for InitializeOpenOrdersCounter {
+    type ArrangedAccounts = InitializeOpenOrdersCounterInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let payer = next_account(&mut iter)?;
+        let user = next_account(&mut iter)?;
+        let open_orders_counter = next_account(&mut iter)?;
+        let deposit_mint = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(InitializeOpenOrdersCounterInstructionAccounts {
+            payer,
+            user,
+            open_orders_counter,
+            deposit_mint,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/mod.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/mod.rs
@@ -1,0 +1,74 @@
+use super::MarketplaceDecoder;
+pub mod add_fee_exemption;
+pub mod add_royalty_tier;
+pub mod delete_royalty_tier;
+pub mod deregister_currency;
+pub mod initialize_marketplace;
+pub mod initialize_open_orders_counter;
+pub mod process_cancel;
+pub mod process_exchange;
+pub mod process_initialize_buy;
+pub mod process_initialize_sell;
+pub mod register_currency;
+pub mod remove_fee_exemption;
+pub mod update_atlas_rate;
+pub mod update_currency_royalty;
+pub mod update_currency_vault;
+pub mod update_royalty_tier;
+
+#[derive(
+    carbon_core::InstructionType,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Hash,
+)]
+pub enum MarketplaceInstruction {
+    AddFeeExemption(add_fee_exemption::AddFeeExemption),
+    AddRoyaltyTier(add_royalty_tier::AddRoyaltyTier),
+    DeleteRoyaltyTier(delete_royalty_tier::DeleteRoyaltyTier),
+    DeregisterCurrency(deregister_currency::DeregisterCurrency),
+    InitializeMarketplace(initialize_marketplace::InitializeMarketplace),
+    InitializeOpenOrdersCounter(initialize_open_orders_counter::InitializeOpenOrdersCounter),
+    ProcessCancel(process_cancel::ProcessCancel),
+    ProcessExchange(process_exchange::ProcessExchange),
+    ProcessInitializeBuy(process_initialize_buy::ProcessInitializeBuy),
+    ProcessInitializeSell(process_initialize_sell::ProcessInitializeSell),
+    RegisterCurrency(register_currency::RegisterCurrency),
+    RemoveFeeExemption(remove_fee_exemption::RemoveFeeExemption),
+    UpdateAtlasRate(update_atlas_rate::UpdateAtlasRate),
+    UpdateCurrencyRoyalty(update_currency_royalty::UpdateCurrencyRoyalty),
+    UpdateCurrencyVault(update_currency_vault::UpdateCurrencyVault),
+    UpdateRoyaltyTier(update_royalty_tier::UpdateRoyaltyTier),
+}
+
+impl<'a> carbon_core::instruction::InstructionDecoder<'a> for MarketplaceDecoder {
+    type InstructionType = MarketplaceInstruction;
+
+    fn decode_instruction(
+        &self,
+        instruction: &solana_instruction::Instruction,
+    ) -> Option<carbon_core::instruction::DecodedInstruction<Self::InstructionType>> {
+        carbon_core::try_decode_instructions!(instruction,
+            MarketplaceInstruction::AddFeeExemption => add_fee_exemption::AddFeeExemption,
+            MarketplaceInstruction::AddRoyaltyTier => add_royalty_tier::AddRoyaltyTier,
+            MarketplaceInstruction::DeleteRoyaltyTier => delete_royalty_tier::DeleteRoyaltyTier,
+            MarketplaceInstruction::DeregisterCurrency => deregister_currency::DeregisterCurrency,
+            MarketplaceInstruction::InitializeMarketplace => initialize_marketplace::InitializeMarketplace,
+            MarketplaceInstruction::InitializeOpenOrdersCounter => initialize_open_orders_counter::InitializeOpenOrdersCounter,
+            MarketplaceInstruction::ProcessCancel => process_cancel::ProcessCancel,
+            MarketplaceInstruction::ProcessExchange => process_exchange::ProcessExchange,
+            MarketplaceInstruction::ProcessInitializeBuy => process_initialize_buy::ProcessInitializeBuy,
+            MarketplaceInstruction::ProcessInitializeSell => process_initialize_sell::ProcessInitializeSell,
+            MarketplaceInstruction::RegisterCurrency => register_currency::RegisterCurrency,
+            MarketplaceInstruction::RemoveFeeExemption => remove_fee_exemption::RemoveFeeExemption,
+            MarketplaceInstruction::UpdateAtlasRate => update_atlas_rate::UpdateAtlasRate,
+            MarketplaceInstruction::UpdateCurrencyRoyalty => update_currency_royalty::UpdateCurrencyRoyalty,
+            MarketplaceInstruction::UpdateCurrencyVault => update_currency_vault::UpdateCurrencyVault,
+            MarketplaceInstruction::UpdateRoyaltyTier => update_royalty_tier::UpdateRoyaltyTier,
+        )
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/process_cancel.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/process_cancel.rs
@@ -1,0 +1,54 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x5554d6f08c29e695")]
+pub struct ProcessCancel {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ProcessCancelInstructionAccounts {
+    pub signer: solana_pubkey::Pubkey,
+    pub order_initializer: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub deposit_mint: solana_pubkey::Pubkey,
+    pub initializer_deposit_token_account: solana_pubkey::Pubkey,
+    pub order_vault_account: solana_pubkey::Pubkey,
+    pub order_vault_authority: solana_pubkey::Pubkey,
+    pub order_account: solana_pubkey::Pubkey,
+    pub open_orders_counter: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for ProcessCancel {
+    type ArrangedAccounts = ProcessCancelInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let signer = next_account(&mut iter)?;
+        let order_initializer = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let deposit_mint = next_account(&mut iter)?;
+        let initializer_deposit_token_account = next_account(&mut iter)?;
+        let order_vault_account = next_account(&mut iter)?;
+        let order_vault_authority = next_account(&mut iter)?;
+        let order_account = next_account(&mut iter)?;
+        let open_orders_counter = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(ProcessCancelInstructionAccounts {
+            signer,
+            order_initializer,
+            market_vars_account,
+            deposit_mint,
+            initializer_deposit_token_account,
+            order_vault_account,
+            order_vault_authority,
+            order_account,
+            open_orders_counter,
+            token_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/process_exchange.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/process_exchange.rs
@@ -1,0 +1,85 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x70c23f6334935530")]
+pub struct ProcessExchange {
+    pub purchase_quantity: u64,
+    pub expected_price: u64,
+    pub seller: solana_pubkey::Pubkey,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ProcessExchangeInstructionAccounts {
+    pub order_taker: solana_pubkey::Pubkey,
+    pub order_taker_deposit_token_account: solana_pubkey::Pubkey,
+    pub order_taker_receive_token_account: solana_pubkey::Pubkey,
+    pub currency_mint: solana_pubkey::Pubkey,
+    pub asset_mint: solana_pubkey::Pubkey,
+    pub order_initializer: solana_pubkey::Pubkey,
+    pub initializer_deposit_token_account: solana_pubkey::Pubkey,
+    pub initializer_receive_token_account: solana_pubkey::Pubkey,
+    pub order_vault_account: solana_pubkey::Pubkey,
+    pub order_vault_authority: solana_pubkey::Pubkey,
+    pub order_account: solana_pubkey::Pubkey,
+    pub sa_vault: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+    pub open_orders_counter: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+    pub atlas_staking: solana_pubkey::Pubkey,
+    pub registered_stake: solana_pubkey::Pubkey,
+    pub staking_account: solana_pubkey::Pubkey,
+    pub fee_reduction: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for ProcessExchange {
+    type ArrangedAccounts = ProcessExchangeInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let order_taker = next_account(&mut iter)?;
+        let order_taker_deposit_token_account = next_account(&mut iter)?;
+        let order_taker_receive_token_account = next_account(&mut iter)?;
+        let currency_mint = next_account(&mut iter)?;
+        let asset_mint = next_account(&mut iter)?;
+        let order_initializer = next_account(&mut iter)?;
+        let initializer_deposit_token_account = next_account(&mut iter)?;
+        let initializer_receive_token_account = next_account(&mut iter)?;
+        let order_vault_account = next_account(&mut iter)?;
+        let order_vault_authority = next_account(&mut iter)?;
+        let order_account = next_account(&mut iter)?;
+        let sa_vault = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+        let open_orders_counter = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+        let atlas_staking = next_account(&mut iter)?;
+        let registered_stake = next_account(&mut iter)?;
+        let staking_account = next_account(&mut iter)?;
+        let fee_reduction = next_account(&mut iter)?;
+
+        Some(ProcessExchangeInstructionAccounts {
+            order_taker,
+            order_taker_deposit_token_account,
+            order_taker_receive_token_account,
+            currency_mint,
+            asset_mint,
+            order_initializer,
+            initializer_deposit_token_account,
+            initializer_receive_token_account,
+            order_vault_account,
+            order_vault_authority,
+            order_account,
+            sa_vault,
+            registered_currency,
+            open_orders_counter,
+            token_program,
+            atlas_staking,
+            registered_stake,
+            staking_account,
+            fee_reduction,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/process_initialize_buy.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/process_initialize_buy.rs
@@ -1,0 +1,69 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x818e66be8a679183")]
+pub struct ProcessInitializeBuy {
+    pub price: u64,
+    pub origination_qty: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ProcessInitializeBuyInstructionAccounts {
+    pub order_initializer: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub deposit_mint: solana_pubkey::Pubkey,
+    pub receive_mint: solana_pubkey::Pubkey,
+    pub order_vault_account: solana_pubkey::Pubkey,
+    pub order_vault_authority: solana_pubkey::Pubkey,
+    pub initializer_deposit_token_account: solana_pubkey::Pubkey,
+    pub initializer_receive_token_account: solana_pubkey::Pubkey,
+    pub order_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+    pub open_orders_counter: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for ProcessInitializeBuy {
+    type ArrangedAccounts = ProcessInitializeBuyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let order_initializer = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let deposit_mint = next_account(&mut iter)?;
+        let receive_mint = next_account(&mut iter)?;
+        let order_vault_account = next_account(&mut iter)?;
+        let order_vault_authority = next_account(&mut iter)?;
+        let initializer_deposit_token_account = next_account(&mut iter)?;
+        let initializer_receive_token_account = next_account(&mut iter)?;
+        let order_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+        let open_orders_counter = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(ProcessInitializeBuyInstructionAccounts {
+            order_initializer,
+            market_vars_account,
+            deposit_mint,
+            receive_mint,
+            order_vault_account,
+            order_vault_authority,
+            initializer_deposit_token_account,
+            initializer_receive_token_account,
+            order_account,
+            registered_currency,
+            open_orders_counter,
+            system_program,
+            rent,
+            token_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/process_initialize_sell.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/process_initialize_sell.rs
@@ -1,0 +1,69 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x2b2aa7fc192fd4e1")]
+pub struct ProcessInitializeSell {
+    pub price: u64,
+    pub origination_qty: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ProcessInitializeSellInstructionAccounts {
+    pub order_initializer: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub deposit_mint: solana_pubkey::Pubkey,
+    pub receive_mint: solana_pubkey::Pubkey,
+    pub order_vault_account: solana_pubkey::Pubkey,
+    pub order_vault_authority: solana_pubkey::Pubkey,
+    pub initializer_deposit_token_account: solana_pubkey::Pubkey,
+    pub initializer_receive_token_account: solana_pubkey::Pubkey,
+    pub order_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+    pub open_orders_counter: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+    pub rent: solana_pubkey::Pubkey,
+    pub token_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for ProcessInitializeSell {
+    type ArrangedAccounts = ProcessInitializeSellInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let order_initializer = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let deposit_mint = next_account(&mut iter)?;
+        let receive_mint = next_account(&mut iter)?;
+        let order_vault_account = next_account(&mut iter)?;
+        let order_vault_authority = next_account(&mut iter)?;
+        let initializer_deposit_token_account = next_account(&mut iter)?;
+        let initializer_receive_token_account = next_account(&mut iter)?;
+        let order_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+        let open_orders_counter = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let rent = next_account(&mut iter)?;
+        let token_program = next_account(&mut iter)?;
+
+        Some(ProcessInitializeSellInstructionAccounts {
+            order_initializer,
+            market_vars_account,
+            deposit_mint,
+            receive_mint,
+            order_vault_account,
+            order_vault_authority,
+            initializer_deposit_token_account,
+            initializer_receive_token_account,
+            order_account,
+            registered_currency,
+            open_orders_counter,
+            system_program,
+            rent,
+            token_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/register_currency.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/register_currency.rs
@@ -1,0 +1,44 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf7e573cc2d24b368")]
+pub struct RegisterCurrency {
+    pub royalty: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct RegisterCurrencyInstructionAccounts {
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+    pub currency_mint: solana_pubkey::Pubkey,
+    pub sa_currency_vault: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for RegisterCurrency {
+    type ArrangedAccounts = RegisterCurrencyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+        let currency_mint = next_account(&mut iter)?;
+        let sa_currency_vault = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(RegisterCurrencyInstructionAccounts {
+            update_authority_account,
+            market_vars_account,
+            registered_currency,
+            currency_mint,
+            sa_currency_vault,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/remove_fee_exemption.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/remove_fee_exemption.rs
@@ -1,0 +1,36 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x9e3b188b1d8d3f0f")]
+pub struct RemoveFeeExemption {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct RemoveFeeExemptionInstructionAccounts {
+    pub update_authority_master: solana_pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub fee_exempt_account: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for RemoveFeeExemption {
+    type ArrangedAccounts = RemoveFeeExemptionInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_master = next_account(&mut iter)?;
+        let funder = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let fee_exempt_account = next_account(&mut iter)?;
+
+        Some(RemoveFeeExemptionInstructionAccounts {
+            update_authority_master,
+            funder,
+            market_vars_account,
+            fee_exempt_account,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/update_atlas_rate.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/update_atlas_rate.rs
@@ -1,0 +1,41 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xf8539e287daecbd4")]
+pub struct UpdateAtlasRate {
+    pub rate: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct UpdateAtlasRateInstructionAccounts {
+    pub funder: solana_pubkey::Pubkey,
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub atlas_rate: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for UpdateAtlasRate {
+    type ArrangedAccounts = UpdateAtlasRateInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let funder = next_account(&mut iter)?;
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let atlas_rate = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(UpdateAtlasRateInstructionAccounts {
+            funder,
+            update_authority_account,
+            market_vars_account,
+            atlas_rate,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/update_currency_royalty.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/update_currency_royalty.rs
@@ -1,0 +1,41 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xb3e8052acc5aaef8")]
+pub struct UpdateCurrencyRoyalty {
+    pub royalty: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct UpdateCurrencyRoyaltyInstructionAccounts {
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+    pub currency_mint: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for UpdateCurrencyRoyalty {
+    type ArrangedAccounts = UpdateCurrencyRoyaltyInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+        let currency_mint = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(UpdateCurrencyRoyaltyInstructionAccounts {
+            update_authority_account,
+            market_vars_account,
+            registered_currency,
+            currency_mint,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/update_currency_vault.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/update_currency_vault.rs
@@ -1,0 +1,42 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x1288481f4cf20a52")]
+pub struct UpdateCurrencyVault {}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct UpdateCurrencyVaultInstructionAccounts {
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+    pub currency_mint: solana_pubkey::Pubkey,
+    pub sa_currency_vault: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for UpdateCurrencyVault {
+    type ArrangedAccounts = UpdateCurrencyVaultInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+        let currency_mint = next_account(&mut iter)?;
+        let sa_currency_vault = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(UpdateCurrencyVaultInstructionAccounts {
+            update_authority_account,
+            market_vars_account,
+            registered_currency,
+            currency_mint,
+            sa_currency_vault,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/instructions/update_royalty_tier.rs
+++ b/carbon-decoders/marketplace-decoder/src/instructions/update_royalty_tier.rs
@@ -1,0 +1,36 @@
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x7b703b7eccb4bfb2")]
+pub struct UpdateRoyaltyTier {
+    pub stake_amount: u64,
+    pub discount: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct UpdateRoyaltyTierInstructionAccounts {
+    pub update_authority_account: solana_pubkey::Pubkey,
+    pub market_vars_account: solana_pubkey::Pubkey,
+    pub registered_currency: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for UpdateRoyaltyTier {
+    type ArrangedAccounts = UpdateRoyaltyTierInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let update_authority_account = next_account(&mut iter)?;
+        let market_vars_account = next_account(&mut iter)?;
+        let registered_currency = next_account(&mut iter)?;
+
+        Some(UpdateRoyaltyTierInstructionAccounts {
+            update_authority_account,
+            market_vars_account,
+            registered_currency,
+        })
+    }
+}

--- a/carbon-decoders/marketplace-decoder/src/lib.rs
+++ b/carbon-decoders/marketplace-decoder/src/lib.rs
@@ -1,0 +1,4 @@
+pub struct MarketplaceDecoder;
+pub mod accounts;
+pub mod instructions;
+pub mod types;

--- a/carbon-decoders/marketplace-decoder/src/types/mod.rs
+++ b/carbon-decoders/marketplace-decoder/src/types/mod.rs
@@ -1,0 +1,4 @@
+pub mod order_side;
+pub use order_side::*;
+pub mod royalty_tier;
+pub use royalty_tier::*;

--- a/carbon-decoders/marketplace-decoder/src/types/order_side.rs
+++ b/carbon-decoders/marketplace-decoder/src/types/order_side.rs
@@ -1,0 +1,9 @@
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+pub enum OrderSide {
+    Buy,
+    Sell,
+}

--- a/carbon-decoders/marketplace-decoder/src/types/royalty_tier.rs
+++ b/carbon-decoders/marketplace-decoder/src/types/royalty_tier.rs
@@ -1,0 +1,9 @@
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+pub struct RoyaltyTier {
+    pub stake_amount: u64,
+    pub discount: u64,
+}

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ SAGE_STARBASED_PROGRAM_ID := "SAGE2HAwep459SNq61LHvjxPk4pLPEJLoMETef7f7EE"
 SAGE_HOLOSIM_PROGRAM_ID := "SAgEeT8u14TE69JXtanGSgNkEdoPUcLabeyZD2uw8x9"
 ATLAS_STAKING_PROGRAM_ID := "ATLocKpzDbTokxgvnLew3d7drZkEzLzDpzwgrgWKDbmc"
 LOCKED_VOTER_PROGRAM_ID := "Lock7kBijGCQLEFAmXcengzXKA88iDNQPriQ7TbgeyG"
+MARKETPLACE_PROGRAM_ID := "traderDnaR5w6Tcoi3NFm53i48FTDNbGjBSZwWXDRrg"
 
 # ============================================================================
 # OS DETECTION FOR CROSS-PLATFORM COMPATIBILITY
@@ -281,11 +282,48 @@ all-locked-voter: build-locked-voter (_apply-patches "locked-voter") (_publish-d
     @echo "✅ locked-voter built, patched, and published"
 
 # ============================================================================
+# MARKETPLACE DECODER COMMANDS
+# ============================================================================
+
+# Generate marketplace decoder from mainnet IDL
+generate-marketplace:
+    #!/bin/bash
+    echo "Fetching IDL from mainnet for {{MARKETPLACE_PROGRAM_ID}}..."
+    carbon-cli parse --idl {{MARKETPLACE_PROGRAM_ID}} -u mainnet-beta --output ./dist --as-crate --standard anchor
+    echo "✅ Decoder generated from mainnet IDL"
+    echo "Renaming to marketplace..."
+    mv ./dist/marketplace-decoder ./dist/marketplace
+    echo "✅ Renamed to marketplace"
+    just _fix-workspace-refs marketplace
+
+# Build marketplace decoder
+build-marketplace: (_clean "marketplace") generate-marketplace (_prepare-decoder "marketplace")
+    @echo "✅ marketplace decoder generated and prepared"
+    just _init-git marketplace
+
+# Clean marketplace decoder
+clean-marketplace: (_clean "marketplace")
+
+# Apply patches for marketplace
+apply-patches-marketplace: (_apply-patches "marketplace")
+
+# Create patch for marketplace
+# Usage: just create-patch-marketplace <patch-name>
+create-patch-marketplace patch_name: (_create-patch "marketplace" patch_name)
+
+# Publish marketplace decoder
+publish-marketplace: (_publish-decoder "marketplace")
+
+# Full pipeline for marketplace
+all-marketplace: build-marketplace (_apply-patches "marketplace") (_publish-decoder "marketplace")
+    @echo "✅ marketplace built, patched, and published"
+
+# ============================================================================
 # UTILITY COMMANDS
 # ============================================================================
 
 # Clean all generated decoders
-clean-all: clean-sage-starbased clean-sage-holosim clean-atlas-staking clean-locked-voter
+clean-all: clean-sage-starbased clean-sage-holosim clean-atlas-staking clean-locked-voter clean-marketplace
     @echo "✅ All decoders cleaned"
 
 # List available patches

--- a/patches/marketplace-01-accounts-serialize.patch
+++ b/patches/marketplace-01-accounts-serialize.patch
@@ -1,0 +1,12 @@
+diff --git a/src/accounts/mod.rs b/src/accounts/mod.rs
+index 34d0258..dc5dbd5 100644
+--- a/src/accounts/mod.rs
++++ b/src/accounts/mod.rs
+@@ -9,6 +9,7 @@ pub mod open_orders_counter;
+ pub mod order_account;
+ pub mod registered_currency;
+ 
++#[derive(Debug, serde::Serialize)]
+ pub enum MarketplaceAccount {
+     AtlasRateAccount(atlas_rate_account::AtlasRateAccount),
+     FeeReduction(fee_reduction::FeeReduction),

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -74,6 +74,13 @@ main() {
     fi
     print_info "✅ locked-voter decoder complete"
 
+    print_info "Building marketplace decoder..."
+    if ! just all-marketplace; then
+        print_error "Failed to build marketplace decoder"
+        exit 1
+    fi
+    print_info "✅ marketplace decoder complete"
+
     # Verify git is still clean
     print_info "Checking final git status..."
     if ! check_git_clean; then


### PR DESCRIPTION
### TL;DR

Added a new decoder for the Star Atlas Galactic Marketplace program.

### What changed?

- Added a new `marketplace-decoder` crate for the Galactic Marketplace program (`traderDnaR5w6Tcoi3NFm53i48FTDNbGjBSZwWXDRrg`)
- Added serialization support for marketplace account types
- Updated build scripts and CI to include the new decoder
- Added documentation in README.md for the marketplace decoder

### How to test?

```bash
# Generate and build the marketplace decoder
just all-marketplace

# Or run individual steps
just build-marketplace
just apply-patches-marketplace
just publish-marketplace

# Verify the decoder works
cargo check -p marketplace-decoder
```

### Why make this change?

The Star Atlas Galactic Marketplace is a critical component of the Star Atlas ecosystem, handling NFT trading with order books, currency management, and royalty tiers. Adding a decoder for this program enables developers to more easily interact with marketplace data, analyze trading activity, and build tools that integrate with the marketplace functionality.