### PR TITLE
feat: add profile-faction decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "carbon-profile-faction-decoder"
+version = "0.10.0"
+dependencies = [
+ "carbon-core",
+ "carbon-macros",
+ "carbon-proc-macros",
+ "serde",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "carbon-profile-vault-decoder"
 version = "0.10.0"
 dependencies = [

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@
   <a href="https://crates.io/crates/carbon-player-profile-decoder">
     <img src="https://img.shields.io/crates/v/carbon-player-profile-decoder?logo=rust&label=player-profile" />
   </a>
+  <a href="https://crates.io/crates/carbon-profile-faction-decoder">
+    <img src="https://img.shields.io/crates/v/carbon-profile-faction-decoder?logo=rust&label=profile-faction" />
+  </a>
 </p>
 
 Rust decoders for Star Atlas Solana programs, generated from IDLs using Carbon CLI with custom patches for complex account deserialization.
@@ -109,6 +112,12 @@ This project generates and maintains Rust decoders for Star Atlas programs on So
   - Custom patches - adds serialization and ergonomic permission bitflags with helper methods
   - Includes permission checking, key expiration validation, and role management
 
+- **profile-faction**: Profile Faction program (`pFACSRuobDmvfMKq1bAzwj27t6d2GJhSCHb1VcfnRmq`)
+  - Fetches IDL directly from Solana mainnet
+  - Player faction affiliation management for Star Atlas universe
+  - Custom patches - adds serialization and type-safe Faction enum
+  - Supports Unaligned, MUD, ONI, and Ustur factions
+
 ## Prerequisites
 
 Run `./scripts/check-tools.sh` to verify all required tools are installed:
@@ -143,7 +152,8 @@ star-atlas-decoders/
 │   ├── profile-vault-decoder/
 │   ├── srsly-decoder/
 │   ├── tcomp-decoder/
-│   └── player-profile-decoder/
+│   ├── player-profile-decoder/
+│   └── profile-faction-decoder/
 ├── dist/                    # Temporary build directory (gitignored)
 ├── patches/                 # Custom patches for decoders
 │   ├── sage-starbased-01-accounts.patch
@@ -161,6 +171,8 @@ star-atlas-decoders/
 │   ├── player-profile-02-permissions-helpers.patch
 │   ├── player-profile-03-remaining-data.patch
 │   └── player-profile-04-instruction-remaining-accounts.patch
+│   ├── profile-faction-01-accounts-serialize.patch
+│   └── profile-faction-02-use-faction-enum.patch
 ├── idl/                     # Local IDL files
 ├── scripts/                 # CI and utility scripts
 │   ├── ci.sh               # Full CI pipeline

--- a/carbon-decoders/profile-faction-decoder/Cargo.toml
+++ b/carbon-decoders/profile-faction-decoder/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "carbon-profile-faction-decoder"
+version = "0.10.0"
+edition = "2024"
+description = "Rust decoder for Star Atlas Profile Faction program on Solana"
+license = "Apache-2.0"
+repository = "https://github.com/staratlasmeta/star-atlas-decoders"
+homepage = "https://github.com/staratlasmeta/star-atlas-decoders"
+readme = "README.md"
+keywords = ["solana", "star-atlas", "decoder"]
+categories = ["encoding"]
+rust-version = "1.85"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+carbon-core = "0.10.0"
+carbon-proc-macros = "0.10.0"
+carbon-macros = "0.10.0"
+solana-account = "2.2.1"
+solana-instruction = { version = "2.3.0", default-features = false }
+solana-pubkey = { version = "2.4.0", features = ["borsh", "serde", "bytemuck"] }
+serde = { version = "1.0", features = ["derive"] }
+

--- a/carbon-decoders/profile-faction-decoder/README.md
+++ b/carbon-decoders/profile-faction-decoder/README.md
@@ -1,0 +1,110 @@
+# Carbon Profile Faction Decoder
+
+<p align="center">
+  <a href="https://crates.io/crates/carbon-profile-faction-decoder">
+    <img src="https://img.shields.io/crates/v/carbon-profile-faction-decoder?logo=rust" />
+  </a>
+  <a href="https://docs.rs/carbon-profile-faction-decoder">
+    <img src="https://img.shields.io/docsrs/carbon-profile-faction-decoder?logo=docsdotrs" />
+  </a>
+  <a href="https://github.com/staratlasmeta/star-atlas-decoders/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-Apache%202.0-blue" />
+  </a>
+</p>
+
+Rust decoder for the Star Atlas Profile Faction program on Solana, generated using [Carbon CLI](https://github.com/sevenlabs-hq/carbon).
+
+## Program Information
+
+- **Program ID**: `pFACSRuobDmvfMKq1bAzwj27t6d2GJhSCHb1VcfnRmq`
+- **Network**: Solana Mainnet
+- **Description**: Star Atlas Profile Faction program for managing player faction affiliations within the Star Atlas universe.
+
+## Features
+
+- Decodes all Profile Faction account types
+- Full instruction parsing support
+- Integration with Carbon indexing framework
+- Type-safe Faction enum for faction selection
+
+## Usage
+
+Add this crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+carbon-profile-faction-decoder = "0.10.0"
+```
+
+### Decoding Accounts
+
+```rust
+use carbon_profile_faction_decoder::{ProfileFactionDecoder, ProfileFactionAccount};
+use carbon_core::account::AccountDecoder;
+
+let decoder = ProfileFactionDecoder;
+let decoded_account = decoder.decode_account(&account);
+
+if let Some(decoded) = decoded_account {
+    match decoded.data {
+        ProfileFactionAccount::ProfileFactionAccount(profile_faction) => {
+            println!("Profile: {:?}", profile_faction.profile);
+            println!("Faction: {:?}", profile_faction.faction);
+            println!("Version: {}", profile_faction.version);
+        }
+    }
+}
+```
+
+### Working with Factions
+
+The decoder includes a type-safe `Faction` enum:
+
+```rust
+use carbon_profile_faction_decoder::{ProfileFactionAccount, Faction};
+
+let profile_faction: ProfileFactionAccount = /* ... */;
+
+// Pattern match on faction
+match profile_faction.faction {
+    Faction::Unaligned => println!("Player has not chosen a faction"),
+    Faction::MUD => println!("Player is aligned with MUD"),
+    Faction::ONI => println!("Player is aligned with ONI"),
+    Faction::Ustur => println!("Player is aligned with Ustur"),
+}
+
+// Check specific faction
+if profile_faction.faction == Faction::MUD {
+    println!("MUD faction member detected");
+}
+```
+
+### Account Types
+
+This decoder supports the Profile Faction account type:
+- `ProfileFactionAccount` - Stores a profile's enlisted faction on-chain
+  - `version: u8` - Account data version
+  - `profile: Pubkey` - The profile this faction enlistment is for
+  - `faction: Faction` - The faction of the profile (type-safe enum)
+  - `bump: u8` - PDA bump seed
+
+### Faction Enum
+
+The `Faction` enum represents the available factions in Star Atlas:
+
+- `Unaligned` - Faction is not selected yet (default)
+- `MUD` - The MUD faction
+- `ONI` - The ONI faction
+- `Ustur` - The Ustur faction
+
+## Documentation
+
+Full documentation is available at [docs.rs](https://docs.rs/carbon-profile-faction-decoder).
+
+## Repository
+
+See the [main repository](https://github.com/staratlasmeta/star-atlas-decoders) for build instructions and contribution guidelines.
+
+## License
+
+Licensed under the [Apache-2.0](https://github.com/staratlasmeta/star-atlas-decoders/blob/main/LICENSE) license.

--- a/carbon-decoders/profile-faction-decoder/src/accounts/mod.rs
+++ b/carbon-decoders/profile-faction-decoder/src/accounts/mod.rs
@@ -1,0 +1,32 @@
+use carbon_core::account::AccountDecoder;
+use carbon_core::deserialize::CarbonDeserialize;
+
+use super::ProfileFactionDecoder;
+pub mod profile_faction_account;
+
+#[derive(Debug, serde::Serialize)]
+pub enum ProfileFactionAccount {
+    ProfileFactionAccount(profile_faction_account::ProfileFactionAccount),
+}
+
+impl<'a> AccountDecoder<'a> for ProfileFactionDecoder {
+    type AccountType = ProfileFactionAccount;
+    fn decode_account(
+        &self,
+        account: &solana_account::Account,
+    ) -> Option<carbon_core::account::DecodedAccount<Self::AccountType>> {
+        if let Some(decoded_account) =
+            profile_faction_account::ProfileFactionAccount::deserialize(account.data.as_slice())
+        {
+            return Some(carbon_core::account::DecodedAccount {
+                lamports: account.lamports,
+                data: ProfileFactionAccount::ProfileFactionAccount(decoded_account),
+                owner: account.owner,
+                executable: account.executable,
+                rent_epoch: account.rent_epoch,
+            });
+        }
+
+        None
+    }
+}

--- a/carbon-decoders/profile-faction-decoder/src/accounts/profile_faction_account.rs
+++ b/carbon-decoders/profile-faction-decoder/src/accounts/profile_faction_account.rs
@@ -1,0 +1,14 @@
+use carbon_core::{CarbonDeserialize, borsh};
+
+use crate::types::Faction;
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0x0e9577f391f04fe3")]
+pub struct ProfileFactionAccount {
+    pub version: u8,
+    pub profile: solana_pubkey::Pubkey,
+    pub faction: Faction,
+    pub bump: u8,
+}

--- a/carbon-decoders/profile-faction-decoder/src/instructions/choose_faction.rs
+++ b/carbon-decoders/profile-faction-decoder/src/instructions/choose_faction.rs
@@ -1,0 +1,44 @@
+use super::super::types::*;
+
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+#[carbon(discriminator = "0xb2e844d95970caaf")]
+pub struct ChooseFaction {
+    pub key_index: u16,
+    pub faction: Faction,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ChooseFactionInstructionAccounts {
+    pub key: solana_pubkey::Pubkey,
+    pub funder: solana_pubkey::Pubkey,
+    pub profile: solana_pubkey::Pubkey,
+    pub faction: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for ChooseFaction {
+    type ArrangedAccounts = ChooseFactionInstructionAccounts;
+
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let key = next_account(&mut iter)?;
+        let funder = next_account(&mut iter)?;
+        let profile = next_account(&mut iter)?;
+        let faction = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+
+        Some(ChooseFactionInstructionAccounts {
+            key,
+            funder,
+            profile,
+            faction,
+            system_program,
+        })
+    }
+}

--- a/carbon-decoders/profile-faction-decoder/src/instructions/mod.rs
+++ b/carbon-decoders/profile-faction-decoder/src/instructions/mod.rs
@@ -1,0 +1,29 @@
+use super::ProfileFactionDecoder;
+pub mod choose_faction;
+
+#[derive(
+    carbon_core::InstructionType,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Debug,
+    Clone,
+    Hash,
+)]
+pub enum ProfileFactionInstruction {
+    ChooseFaction(choose_faction::ChooseFaction),
+}
+
+impl<'a> carbon_core::instruction::InstructionDecoder<'a> for ProfileFactionDecoder {
+    type InstructionType = ProfileFactionInstruction;
+
+    fn decode_instruction(
+        &self,
+        instruction: &solana_instruction::Instruction,
+    ) -> Option<carbon_core::instruction::DecodedInstruction<Self::InstructionType>> {
+        carbon_core::try_decode_instructions!(instruction,
+            ProfileFactionInstruction::ChooseFaction => choose_faction::ChooseFaction,
+        )
+    }
+}

--- a/carbon-decoders/profile-faction-decoder/src/lib.rs
+++ b/carbon-decoders/profile-faction-decoder/src/lib.rs
@@ -1,0 +1,4 @@
+pub struct ProfileFactionDecoder;
+pub mod accounts;
+pub mod instructions;
+pub mod types;

--- a/carbon-decoders/profile-faction-decoder/src/types/faction.rs
+++ b/carbon-decoders/profile-faction-decoder/src/types/faction.rs
@@ -1,0 +1,11 @@
+use carbon_core::{CarbonDeserialize, borsh};
+
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
+pub enum Faction {
+    Unaligned,
+    MUD,
+    ONI,
+    Ustur,
+}

--- a/carbon-decoders/profile-faction-decoder/src/types/mod.rs
+++ b/carbon-decoders/profile-faction-decoder/src/types/mod.rs
@@ -1,0 +1,2 @@
+pub mod faction;
+pub use faction::*;

--- a/docs/readmes/profile-faction-README.md
+++ b/docs/readmes/profile-faction-README.md
@@ -1,0 +1,110 @@
+# Carbon Profile Faction Decoder
+
+<p align="center">
+  <a href="https://crates.io/crates/carbon-profile-faction-decoder">
+    <img src="https://img.shields.io/crates/v/carbon-profile-faction-decoder?logo=rust" />
+  </a>
+  <a href="https://docs.rs/carbon-profile-faction-decoder">
+    <img src="https://img.shields.io/docsrs/carbon-profile-faction-decoder?logo=docsdotrs" />
+  </a>
+  <a href="https://github.com/staratlasmeta/star-atlas-decoders/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-Apache%202.0-blue" />
+  </a>
+</p>
+
+Rust decoder for the Star Atlas Profile Faction program on Solana, generated using [Carbon CLI](https://github.com/sevenlabs-hq/carbon).
+
+## Program Information
+
+- **Program ID**: `pFACSRuobDmvfMKq1bAzwj27t6d2GJhSCHb1VcfnRmq`
+- **Network**: Solana Mainnet
+- **Description**: Star Atlas Profile Faction program for managing player faction affiliations within the Star Atlas universe.
+
+## Features
+
+- Decodes all Profile Faction account types
+- Full instruction parsing support
+- Integration with Carbon indexing framework
+- Type-safe Faction enum for faction selection
+
+## Usage
+
+Add this crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+carbon-profile-faction-decoder = "0.10.0"
+```
+
+### Decoding Accounts
+
+```rust
+use carbon_profile_faction_decoder::{ProfileFactionDecoder, ProfileFactionAccount};
+use carbon_core::account::AccountDecoder;
+
+let decoder = ProfileFactionDecoder;
+let decoded_account = decoder.decode_account(&account);
+
+if let Some(decoded) = decoded_account {
+    match decoded.data {
+        ProfileFactionAccount::ProfileFactionAccount(profile_faction) => {
+            println!("Profile: {:?}", profile_faction.profile);
+            println!("Faction: {:?}", profile_faction.faction);
+            println!("Version: {}", profile_faction.version);
+        }
+    }
+}
+```
+
+### Working with Factions
+
+The decoder includes a type-safe `Faction` enum:
+
+```rust
+use carbon_profile_faction_decoder::{ProfileFactionAccount, Faction};
+
+let profile_faction: ProfileFactionAccount = /* ... */;
+
+// Pattern match on faction
+match profile_faction.faction {
+    Faction::Unaligned => println!("Player has not chosen a faction"),
+    Faction::MUD => println!("Player is aligned with MUD"),
+    Faction::ONI => println!("Player is aligned with ONI"),
+    Faction::Ustur => println!("Player is aligned with Ustur"),
+}
+
+// Check specific faction
+if profile_faction.faction == Faction::MUD {
+    println!("MUD faction member detected");
+}
+```
+
+### Account Types
+
+This decoder supports the Profile Faction account type:
+- `ProfileFactionAccount` - Stores a profile's enlisted faction on-chain
+  - `version: u8` - Account data version
+  - `profile: Pubkey` - The profile this faction enlistment is for
+  - `faction: Faction` - The faction of the profile (type-safe enum)
+  - `bump: u8` - PDA bump seed
+
+### Faction Enum
+
+The `Faction` enum represents the available factions in Star Atlas:
+
+- `Unaligned` - Faction is not selected yet (default)
+- `MUD` - The MUD faction
+- `ONI` - The ONI faction
+- `Ustur` - The Ustur faction
+
+## Documentation
+
+Full documentation is available at [docs.rs](https://docs.rs/carbon-profile-faction-decoder).
+
+## Repository
+
+See the [main repository](https://github.com/staratlasmeta/star-atlas-decoders) for build instructions and contribution guidelines.
+
+## License
+
+Licensed under the [Apache-2.0](https://github.com/staratlasmeta/star-atlas-decoders/blob/main/LICENSE) license.

--- a/justfile
+++ b/justfile
@@ -5,12 +5,13 @@
 # ============================================================================
 
 # List of all decoders (space-separated)
-ALL_DECODERS := "sage-starbased sage-holosim atlas-staking locked-voter marketplace atlas-fee-payer crew profile-vault srsly tcomp player-profile"
+ALL_DECODERS := "sage-starbased sage-holosim atlas-staking locked-voter marketplace atlas-fee-payer crew profile-vault srsly tcomp player-profile profile-faction"
 
 # Program IDs
 ATLAS_FEE_PAYER_PROGRAM_ID := "APR1MEny25pKupwn72oVqMH4qpDouArsX8zX4VwwfoXD"
 CREW_PROGRAM_ID := "CREWiq8qbxvo4SKkAFpVnc6t7CRQC4tAAscsNAENXgrJ"
 PLAYER_PROFILE_PROGRAM_ID := "pprofELXjL5Kck7Jn5hCpwAL82DpTkSYBENzahVtbc9"
+PROFILE_FACTION_PROGRAM_ID := "pFACSRuobDmvfMKq1bAzwj27t6d2GJhSCHb1VcfnRmq"
 PROFILE_VAULT_PROGRAM_ID := "pv1ttom8tbyh83C1AVh6QH2naGRdVQUVt3HY1Yst5sv"
 SAGE_STARBASED_PROGRAM_ID := "SAGE2HAwep459SNq61LHvjxPk4pLPEJLoMETef7f7EE"
 SAGE_HOLOSIM_PROGRAM_ID := "SAgEeT8u14TE69JXtanGSgNkEdoPUcLabeyZD2uw8x9"
@@ -24,6 +25,7 @@ MARKETPLACE_PROGRAM_ID := "traderDnaR5w6Tcoi3NFm53i48FTDNbGjBSZwWXDRrg"
 ATLAS_FEE_PAYER_DESC := "Rust decoder for Star Atlas ATLAS fee payer program on Solana"
 CREW_DESC := "Rust decoder for Star Atlas Crew management program on Solana"
 PLAYER_PROFILE_DESC := "Rust decoder for Star Atlas Player Profile program on Solana"
+PROFILE_FACTION_DESC := "Rust decoder for Star Atlas Profile Faction program on Solana"
 PROFILE_VAULT_DESC := "Rust decoder for Star Atlas Profile Vault program on Solana"
 SRSLY_DESC := "Rust decoder for Star Atlas Fleet Rentals (SRSLY) program on Solana"
 TCOMP_DESC := "Rust decoder for Tensor cNFT Compressed program on Solana"
@@ -37,6 +39,7 @@ MARKETPLACE_DESC := "Rust decoder for Star Atlas Galactic Marketplace program on
 ATLAS_FEE_PAYER_SOURCE := "mainnet"
 CREW_SOURCE := "mainnet"
 PLAYER_PROFILE_SOURCE := "mainnet"
+PROFILE_FACTION_SOURCE := "mainnet"
 PROFILE_VAULT_SOURCE := "mainnet"
 SRSLY_SOURCE := "mainnet"
 TCOMP_SOURCE := "mainnet"
@@ -55,6 +58,7 @@ MARKETPLACE_GENERATED_NAME := "marketplace-decoder"
 ATLAS_FEE_PAYER_GENERATED_NAME := "atlas-fee-payer-decoder"
 CREW_GENERATED_NAME := "crew-decoder"
 PLAYER_PROFILE_GENERATED_NAME := "player-profile-decoder"
+PROFILE_FACTION_GENERATED_NAME := "profile-faction-decoder"
 PROFILE_VAULT_GENERATED_NAME := "profile-vault-decoder"
 SRSLY_GENERATED_NAME := "srsly-decoder"
 TCOMP_GENERATED_NAME := "tcomp-decoder"
@@ -91,6 +95,7 @@ _get-program-id decoder_name:
         atlas-fee-payer) echo "{{ATLAS_FEE_PAYER_PROGRAM_ID}}" ;;
         crew) echo "{{CREW_PROGRAM_ID}}" ;;
         player-profile) echo "{{PLAYER_PROFILE_PROGRAM_ID}}" ;;
+        profile-faction) echo "{{PROFILE_FACTION_PROGRAM_ID}}" ;;
         profile-vault) echo "{{PROFILE_VAULT_PROGRAM_ID}}" ;;
         srsly) echo "{{SRSLY_PROGRAM_ID}}" ;;
         tcomp) echo "{{TENSOR_TCOMP_PROGRAM_ID}}" ;;
@@ -109,6 +114,7 @@ _get-description decoder_name:
         atlas-fee-payer) echo "{{ATLAS_FEE_PAYER_DESC}}" ;;
         crew) echo "{{CREW_DESC}}" ;;
         player-profile) echo "{{PLAYER_PROFILE_DESC}}" ;;
+        profile-faction) echo "{{PROFILE_FACTION_DESC}}" ;;
         profile-vault) echo "{{PROFILE_VAULT_DESC}}" ;;
         srsly) echo "{{SRSLY_DESC}}" ;;
         tcomp) echo "{{TCOMP_DESC}}" ;;
@@ -127,6 +133,7 @@ _get-source decoder_name:
         atlas-fee-payer) echo "{{ATLAS_FEE_PAYER_SOURCE}}" ;;
         crew) echo "{{CREW_SOURCE}}" ;;
         player-profile) echo "{{PLAYER_PROFILE_SOURCE}}" ;;
+        profile-faction) echo "{{PROFILE_FACTION_SOURCE}}" ;;
         profile-vault) echo "{{PROFILE_VAULT_SOURCE}}" ;;
         srsly) echo "{{SRSLY_SOURCE}}" ;;
         tcomp) echo "{{TCOMP_SOURCE}}" ;;
@@ -145,6 +152,7 @@ _get-generated-name decoder_name:
         atlas-fee-payer) echo "{{ATLAS_FEE_PAYER_GENERATED_NAME}}" ;;
         crew) echo "{{CREW_GENERATED_NAME}}" ;;
         player-profile) echo "{{PLAYER_PROFILE_GENERATED_NAME}}" ;;
+        profile-faction) echo "{{PROFILE_FACTION_GENERATED_NAME}}" ;;
         profile-vault) echo "{{PROFILE_VAULT_GENERATED_NAME}}" ;;
         srsly) echo "{{SRSLY_GENERATED_NAME}}" ;;
         tcomp) echo "{{TCOMP_GENERATED_NAME}}" ;;
@@ -480,6 +488,15 @@ apply-patches-player-profile: (apply-patches "player-profile")
 create-patch-player-profile patch_name: (create-patch "player-profile" patch_name)
 publish-player-profile: (publish "player-profile")
 all-player-profile: (all "player-profile")
+
+# Profile Faction
+generate-profile-faction: (generate "profile-faction")
+build-profile-faction: (build "profile-faction")
+clean-profile-faction: (clean "profile-faction")
+apply-patches-profile-faction: (apply-patches "profile-faction")
+create-patch-profile-faction patch_name: (create-patch "profile-faction" patch_name)
+publish-profile-faction: (publish "profile-faction")
+all-profile-faction: (all "profile-faction")
 
 # ============================================================================
 # UTILITY COMMANDS

--- a/patches/profile-faction-01-accounts-serialize.patch
+++ b/patches/profile-faction-01-accounts-serialize.patch
@@ -1,0 +1,12 @@
+diff --git a/src/accounts/mod.rs b/src/accounts/mod.rs
+index 0f09f4b..46ebc4b 100644
+--- a/src/accounts/mod.rs
++++ b/src/accounts/mod.rs
+@@ -4,6 +4,7 @@ use carbon_core::deserialize::CarbonDeserialize;
+ use super::ProfileFactionDecoder;
+ pub mod profile_faction_account;
+ 
++#[derive(Debug, serde::Serialize)]
+ pub enum ProfileFactionAccount {
+     ProfileFactionAccount(profile_faction_account::ProfileFactionAccount),
+ }

--- a/patches/profile-faction-02-use-faction-enum.patch
+++ b/patches/profile-faction-02-use-faction-enum.patch
@@ -1,0 +1,20 @@
+diff --git a/src/accounts/profile_faction_account.rs b/src/accounts/profile_faction_account.rs
+index 41aea74..1c3e01a 100644
+--- a/src/accounts/profile_faction_account.rs
++++ b/src/accounts/profile_faction_account.rs
+@@ -1,5 +1,7 @@
+ use carbon_core::{CarbonDeserialize, borsh};
+ 
++use crate::types::Faction;
++
+ #[derive(
+     CarbonDeserialize, Debug, serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Hash,
+ )]
+@@ -7,6 +9,6 @@ use carbon_core::{CarbonDeserialize, borsh};
+ pub struct ProfileFactionAccount {
+     pub version: u8,
+     pub profile: solana_pubkey::Pubkey,
+-    pub faction: u8,
++    pub faction: Faction,
+     pub bump: u8,
+ }


### PR DESCRIPTION
### TL;DR

Added a new decoder for the Star Atlas Profile Faction program that manages player faction affiliations.

### What changed?

- Created a new `carbon-profile-faction-decoder` crate for the Profile Faction program (`pFACSRuobDmvfMKq1bAzwj27t6d2GJhSCHb1VcfnRmq`)
- Implemented account and instruction decoding for the Profile Faction program
- Added a type-safe `Faction` enum (Unaligned, MUD, ONI, Ustur) for better faction handling
- Added serialization support for account types
- Updated project documentation and build scripts to include the new decoder
- Added custom patches for serialization and type-safe faction enum

### Why make this change?

This decoder enables applications to interact with the Star Atlas Profile Faction program, which manages player faction affiliations within the Star Atlas universe. The type-safe `Faction` enum improves developer experience by providing compile-time checking for faction values instead of using raw numeric values, reducing potential errors when working with faction data.