### PR TITLE
chore: fix CargoPod patch for list length and cargo contents

### DIFF
--- a/patches/cargo-03-remaining-data.patch
+++ b/patches/cargo-03-remaining-data.patch
@@ -1,5 +1,5 @@
 diff --git a/src/accounts/cargo_pod.rs b/src/accounts/cargo_pod.rs
-index cab42f3..05b3edd 100644
+index cab42f3..cbdbe6e 100644
 --- a/src/accounts/cargo_pod.rs
 +++ b/src/accounts/cargo_pod.rs
 @@ -1,9 +1,6 @@
@@ -14,7 +14,7 @@ index cab42f3..05b3edd 100644
  pub struct CargoPod {
      pub version: u8,
      pub stats_definition: solana_pubkey::Pubkey,
-@@ -13,4 +10,78 @@ pub struct CargoPod {
+@@ -13,4 +10,83 @@ pub struct CargoPod {
      pub pod_bump: u8,
      pub seq_id: u16,
      pub unupdated_token_accounts: u8,
@@ -59,20 +59,25 @@ index cab42f3..05b3edd 100644
 +        }
 +
 +        // CargoPod has RemainingData = List<PackedValue<u64>>
-+        // Contains the contents of the cargo pod as a list of u64 (no length prefix in account)
++        // Contains the contents of the cargo pod as a list of u64 with a u32 length prefix
 +        // Byte layout: version(1) + stats_definition(32) + authority(32) + open_token_accounts(1) + pod_seeds(32) + pod_bump(1) + seq_id(2) + unupdated_token_accounts(1) = 102 bytes
-+        // All remaining bytes after fixed fields are u64 cargo values
++        // After fixed fields: u32 length prefix (4 bytes) + list of u64 cargo values (8 bytes each)
 +
 +        let cargo_pod: CargoPod = match BorshDeserialize::deserialize(&mut rest) {
 +            Ok(res) => res,
 +            Err(_) => return None,
 +        };
 +
-+        // Read all remaining bytes as u64 values (each u64 is 8 bytes)
-+        let num_u64_values = rest.len() / 8;
-+        let mut cargo_contents = Vec::with_capacity(num_u64_values);
++        // Read u32 length prefix from remaining data
++        let list_length: u32 = match BorshDeserialize::deserialize(&mut rest) {
++            Ok(len) => len,
++            Err(_) => return None,
++        };
 +
-+        for _ in 0..num_u64_values {
++        // Read list_length u64 values
++        let mut cargo_contents = Vec::with_capacity(list_length as usize);
++
++        for _ in 0..list_length {
 +            match BorshDeserialize::deserialize(&mut rest) {
 +                Ok(value) => cargo_contents.push(value),
 +                Err(_) => return None,


### PR DESCRIPTION
### TL;DR

Updated the CargoPod decoder to handle a u32 length prefix in the cargo contents data structure.

### What changed?

- Modified the CargoPod deserializer to read a u32 length prefix before reading the list of u64 cargo values
- Updated the comments to reflect that the cargo pod contents now include a length prefix
- Changed the deserialization logic to read exactly the number of u64 values specified by the length prefix, rather than consuming all remaining bytes

### How to test?

- Test deserializing CargoPod accounts with the new format that includes a length prefix
- Verify that the decoder correctly reads the exact number of u64 values specified in the length prefix
- Ensure backward compatibility is maintained if needed

### Why make this change?

The CargoPod account structure has been updated to include a length prefix for the cargo contents, which provides better data integrity and validation. This change ensures the decoder correctly interprets the new account structure format, preventing potential issues where the decoder might try to read invalid data beyond the actual cargo contents.